### PR TITLE
add pop-weighted national average to combined_file

### DIFF
--- a/Data/other_data/Single-Race Population Estimates 2020-2023 by State and Single-Year Age.csv
+++ b/Data/other_data/Single-Race Population Estimates 2020-2023 by State and Single-Year Age.csv
@@ -1,0 +1,4466 @@
+"Notes"	"States"	"States Code"	"Single-Year Ages"	"Single-Year Ages Code"	Population
+	"Alabama"	"01"	"< 1 year"	"0"	57885
+	"Alabama"	"01"	"1 year"	"1"	58419
+	"Alabama"	"01"	"2 years"	"2"	58006
+	"Alabama"	"01"	"3 years"	"3"	59016
+	"Alabama"	"01"	"4 years"	"4"	59779
+	"Alabama"	"01"	"5 years"	"5"	61507
+	"Alabama"	"01"	"6 years"	"6"	61999
+	"Alabama"	"01"	"7 years"	"7"	62999
+	"Alabama"	"01"	"8 years"	"8"	63416
+	"Alabama"	"01"	"9 years"	"9"	62673
+	"Alabama"	"01"	"10 years"	"10"	62154
+	"Alabama"	"01"	"11 years"	"11"	62540
+	"Alabama"	"01"	"12 years"	"12"	63387
+	"Alabama"	"01"	"13 years"	"13"	64905
+	"Alabama"	"01"	"14 years"	"14"	66848
+	"Alabama"	"01"	"15 years"	"15"	69479
+	"Alabama"	"01"	"16 years"	"16"	68941
+	"Alabama"	"01"	"17 years"	"17"	66887
+	"Alabama"	"01"	"18 years"	"18"	67793
+	"Alabama"	"01"	"19 years"	"19"	71779
+	"Alabama"	"01"	"20 years"	"20"	68567
+	"Alabama"	"01"	"21 years"	"21"	68152
+	"Alabama"	"01"	"22 years"	"22"	69247
+	"Alabama"	"01"	"23 years"	"23"	68558
+	"Alabama"	"01"	"24 years"	"24"	66199
+	"Alabama"	"01"	"25 years"	"25"	64933
+	"Alabama"	"01"	"26 years"	"26"	63403
+	"Alabama"	"01"	"27 years"	"27"	62633
+	"Alabama"	"01"	"28 years"	"28"	63533
+	"Alabama"	"01"	"29 years"	"29"	65238
+	"Alabama"	"01"	"30 years"	"30"	66208
+	"Alabama"	"01"	"31 years"	"31"	68027
+	"Alabama"	"01"	"32 years"	"32"	69865
+	"Alabama"	"01"	"33 years"	"33"	69943
+	"Alabama"	"01"	"34 years"	"34"	67012
+	"Alabama"	"01"	"35 years"	"35"	64362
+	"Alabama"	"01"	"36 years"	"36"	63238
+	"Alabama"	"01"	"37 years"	"37"	62988
+	"Alabama"	"01"	"38 years"	"38"	63208
+	"Alabama"	"01"	"39 years"	"39"	61800
+	"Alabama"	"01"	"40 years"	"40"	62851
+	"Alabama"	"01"	"41 years"	"41"	63756
+	"Alabama"	"01"	"42 years"	"42"	63508
+	"Alabama"	"01"	"43 years"	"43"	64058
+	"Alabama"	"01"	"44 years"	"44"	61428
+	"Alabama"	"01"	"45 years"	"45"	60548
+	"Alabama"	"01"	"46 years"	"46"	60209
+	"Alabama"	"01"	"47 years"	"47"	58168
+	"Alabama"	"01"	"48 years"	"48"	59160
+	"Alabama"	"01"	"49 years"	"49"	59241
+	"Alabama"	"01"	"50 years"	"50"	60692
+	"Alabama"	"01"	"51 years"	"51"	64276
+	"Alabama"	"01"	"52 years"	"52"	68132
+	"Alabama"	"01"	"53 years"	"53"	65820
+	"Alabama"	"01"	"54 years"	"54"	62717
+	"Alabama"	"01"	"55 years"	"55"	61348
+	"Alabama"	"01"	"56 years"	"56"	61567
+	"Alabama"	"01"	"57 years"	"57"	63053
+	"Alabama"	"01"	"58 years"	"58"	66021
+	"Alabama"	"01"	"59 years"	"59"	67688
+	"Alabama"	"01"	"60 years"	"60"	67368
+	"Alabama"	"01"	"61 years"	"61"	68042
+	"Alabama"	"01"	"62 years"	"62"	67832
+	"Alabama"	"01"	"63 years"	"63"	66322
+	"Alabama"	"01"	"64 years"	"64"	64825
+	"Alabama"	"01"	"65 years"	"65"	64174
+	"Alabama"	"01"	"66 years"	"66"	63606
+	"Alabama"	"01"	"67 years"	"67"	61003
+	"Alabama"	"01"	"68 years"	"68"	59017
+	"Alabama"	"01"	"69 years"	"69"	56690
+	"Alabama"	"01"	"70 years"	"70"	54066
+	"Alabama"	"01"	"71 years"	"71"	51517
+	"Alabama"	"01"	"72 years"	"72"	48971
+	"Alabama"	"01"	"73 years"	"73"	46398
+	"Alabama"	"01"	"74 years"	"74"	45481
+	"Alabama"	"01"	"75 years"	"75"	44035
+	"Alabama"	"01"	"76 years"	"76"	46168
+	"Alabama"	"01"	"77 years"	"77"	31784
+	"Alabama"	"01"	"78 years"	"78"	30468
+	"Alabama"	"01"	"79 years"	"79"	29050
+	"Alabama"	"01"	"80 years"	"80"	28898
+	"Alabama"	"01"	"81 years"	"81"	23930
+	"Alabama"	"01"	"82 years"	"82"	20815
+	"Alabama"	"01"	"83 years"	"83"	18733
+	"Alabama"	"01"	"84 years"	"84"	17089
+	"Alabama"	"01"	"85+ years"	"85+"	90419
+"Total"	"Alabama"	"01"			5108468
+	"Alaska"	"02"	"< 1 year"	"0"	9224
+	"Alaska"	"02"	"1 year"	"1"	9163
+	"Alaska"	"02"	"2 years"	"2"	9054
+	"Alaska"	"02"	"3 years"	"3"	9286
+	"Alaska"	"02"	"4 years"	"4"	9130
+	"Alaska"	"02"	"5 years"	"5"	9403
+	"Alaska"	"02"	"6 years"	"6"	9944
+	"Alaska"	"02"	"7 years"	"7"	10065
+	"Alaska"	"02"	"8 years"	"8"	10204
+	"Alaska"	"02"	"9 years"	"9"	10166
+	"Alaska"	"02"	"10 years"	"10"	10220
+	"Alaska"	"02"	"11 years"	"11"	10008
+	"Alaska"	"02"	"12 years"	"12"	10108
+	"Alaska"	"02"	"13 years"	"13"	10025
+	"Alaska"	"02"	"14 years"	"14"	10028
+	"Alaska"	"02"	"15 years"	"15"	10100
+	"Alaska"	"02"	"16 years"	"16"	9822
+	"Alaska"	"02"	"17 years"	"17"	9557
+	"Alaska"	"02"	"18 years"	"18"	8465
+	"Alaska"	"02"	"19 years"	"19"	7930
+	"Alaska"	"02"	"20 years"	"20"	9045
+	"Alaska"	"02"	"21 years"	"21"	9634
+	"Alaska"	"02"	"22 years"	"22"	10302
+	"Alaska"	"02"	"23 years"	"23"	10316
+	"Alaska"	"02"	"24 years"	"24"	10539
+	"Alaska"	"02"	"25 years"	"25"	10478
+	"Alaska"	"02"	"26 years"	"26"	10577
+	"Alaska"	"02"	"27 years"	"27"	10554
+	"Alaska"	"02"	"28 years"	"28"	10692
+	"Alaska"	"02"	"29 years"	"29"	10994
+	"Alaska"	"02"	"30 years"	"30"	11441
+	"Alaska"	"02"	"31 years"	"31"	11942
+	"Alaska"	"02"	"32 years"	"32"	12038
+	"Alaska"	"02"	"33 years"	"33"	12053
+	"Alaska"	"02"	"34 years"	"34"	11588
+	"Alaska"	"02"	"35 years"	"35"	11389
+	"Alaska"	"02"	"36 years"	"36"	11238
+	"Alaska"	"02"	"37 years"	"37"	11418
+	"Alaska"	"02"	"38 years"	"38"	11220
+	"Alaska"	"02"	"39 years"	"39"	10759
+	"Alaska"	"02"	"40 years"	"40"	10830
+	"Alaska"	"02"	"41 years"	"41"	10535
+	"Alaska"	"02"	"42 years"	"42"	9970
+	"Alaska"	"02"	"43 years"	"43"	9586
+	"Alaska"	"02"	"44 years"	"44"	9019
+	"Alaska"	"02"	"45 years"	"45"	8767
+	"Alaska"	"02"	"46 years"	"46"	8445
+	"Alaska"	"02"	"47 years"	"47"	8098
+	"Alaska"	"02"	"48 years"	"48"	8062
+	"Alaska"	"02"	"49 years"	"49"	7775
+	"Alaska"	"02"	"50 years"	"50"	7970
+	"Alaska"	"02"	"51 years"	"51"	8314
+	"Alaska"	"02"	"52 years"	"52"	8697
+	"Alaska"	"02"	"53 years"	"53"	8523
+	"Alaska"	"02"	"54 years"	"54"	8221
+	"Alaska"	"02"	"55 years"	"55"	7911
+	"Alaska"	"02"	"56 years"	"56"	7903
+	"Alaska"	"02"	"57 years"	"57"	8142
+	"Alaska"	"02"	"58 years"	"58"	8459
+	"Alaska"	"02"	"59 years"	"59"	8732
+	"Alaska"	"02"	"60 years"	"60"	8943
+	"Alaska"	"02"	"61 years"	"61"	8901
+	"Alaska"	"02"	"62 years"	"62"	8965
+	"Alaska"	"02"	"63 years"	"63"	8772
+	"Alaska"	"02"	"64 years"	"64"	8436
+	"Alaska"	"02"	"65 years"	"65"	8248
+	"Alaska"	"02"	"66 years"	"66"	8120
+	"Alaska"	"02"	"67 years"	"67"	7687
+	"Alaska"	"02"	"68 years"	"68"	7689
+	"Alaska"	"02"	"69 years"	"69"	7407
+	"Alaska"	"02"	"70 years"	"70"	6937
+	"Alaska"	"02"	"71 years"	"71"	6424
+	"Alaska"	"02"	"72 years"	"72"	5962
+	"Alaska"	"02"	"73 years"	"73"	5600
+	"Alaska"	"02"	"74 years"	"74"	5220
+	"Alaska"	"02"	"75 years"	"75"	4754
+	"Alaska"	"02"	"76 years"	"76"	4769
+	"Alaska"	"02"	"77 years"	"77"	3313
+	"Alaska"	"02"	"78 years"	"78"	3168
+	"Alaska"	"02"	"79 years"	"79"	2931
+	"Alaska"	"02"	"80 years"	"80"	2682
+	"Alaska"	"02"	"81 years"	"81"	2229
+	"Alaska"	"02"	"82 years"	"82"	2018
+	"Alaska"	"02"	"83 years"	"83"	1713
+	"Alaska"	"02"	"84 years"	"84"	1401
+	"Alaska"	"02"	"85+ years"	"85+"	7039
+"Total"	"Alaska"	"02"			733406
+	"Arizona"	"04"	"< 1 year"	"0"	78075
+	"Arizona"	"04"	"1 year"	"1"	79101
+	"Arizona"	"04"	"2 years"	"2"	76514
+	"Arizona"	"04"	"3 years"	"3"	78959
+	"Arizona"	"04"	"4 years"	"4"	80882
+	"Arizona"	"04"	"5 years"	"5"	82808
+	"Arizona"	"04"	"6 years"	"6"	85303
+	"Arizona"	"04"	"7 years"	"7"	87984
+	"Arizona"	"04"	"8 years"	"8"	90021
+	"Arizona"	"04"	"9 years"	"9"	89883
+	"Arizona"	"04"	"10 years"	"10"	89255
+	"Arizona"	"04"	"11 years"	"11"	89138
+	"Arizona"	"04"	"12 years"	"12"	90107
+	"Arizona"	"04"	"13 years"	"13"	92332
+	"Arizona"	"04"	"14 years"	"14"	95257
+	"Arizona"	"04"	"15 years"	"15"	99276
+	"Arizona"	"04"	"16 years"	"16"	99877
+	"Arizona"	"04"	"17 years"	"17"	98262
+	"Arizona"	"04"	"18 years"	"18"	99195
+	"Arizona"	"04"	"19 years"	"19"	100076
+	"Arizona"	"04"	"20 years"	"20"	97371
+	"Arizona"	"04"	"21 years"	"21"	98911
+	"Arizona"	"04"	"22 years"	"22"	102338
+	"Arizona"	"04"	"23 years"	"23"	104464
+	"Arizona"	"04"	"24 years"	"24"	102044
+	"Arizona"	"04"	"25 years"	"25"	101901
+	"Arizona"	"04"	"26 years"	"26"	101313
+	"Arizona"	"04"	"27 years"	"27"	101026
+	"Arizona"	"04"	"28 years"	"28"	101123
+	"Arizona"	"04"	"29 years"	"29"	102747
+	"Arizona"	"04"	"30 years"	"30"	103283
+	"Arizona"	"04"	"31 years"	"31"	104643
+	"Arizona"	"04"	"32 years"	"32"	105725
+	"Arizona"	"04"	"33 years"	"33"	104796
+	"Arizona"	"04"	"34 years"	"34"	100472
+	"Arizona"	"04"	"35 years"	"35"	98134
+	"Arizona"	"04"	"36 years"	"36"	95847
+	"Arizona"	"04"	"37 years"	"37"	96201
+	"Arizona"	"04"	"38 years"	"38"	95801
+	"Arizona"	"04"	"39 years"	"39"	92962
+	"Arizona"	"04"	"40 years"	"40"	94692
+	"Arizona"	"04"	"41 years"	"41"	94720
+	"Arizona"	"04"	"42 years"	"42"	93973
+	"Arizona"	"04"	"43 years"	"43"	93177
+	"Arizona"	"04"	"44 years"	"44"	88370
+	"Arizona"	"04"	"45 years"	"45"	86163
+	"Arizona"	"04"	"46 years"	"46"	85774
+	"Arizona"	"04"	"47 years"	"47"	83190
+	"Arizona"	"04"	"48 years"	"48"	84535
+	"Arizona"	"04"	"49 years"	"49"	83055
+	"Arizona"	"04"	"50 years"	"50"	82928
+	"Arizona"	"04"	"51 years"	"51"	86081
+	"Arizona"	"04"	"52 years"	"52"	91434
+	"Arizona"	"04"	"53 years"	"53"	89527
+	"Arizona"	"04"	"54 years"	"54"	86221
+	"Arizona"	"04"	"55 years"	"55"	83454
+	"Arizona"	"04"	"56 years"	"56"	82971
+	"Arizona"	"04"	"57 years"	"57"	83840
+	"Arizona"	"04"	"58 years"	"58"	87202
+	"Arizona"	"04"	"59 years"	"59"	89312
+	"Arizona"	"04"	"60 years"	"60"	90149
+	"Arizona"	"04"	"61 years"	"61"	91370
+	"Arizona"	"04"	"62 years"	"62"	91536
+	"Arizona"	"04"	"63 years"	"63"	90566
+	"Arizona"	"04"	"64 years"	"64"	89178
+	"Arizona"	"04"	"65 years"	"65"	89458
+	"Arizona"	"04"	"66 years"	"66"	88789
+	"Arizona"	"04"	"67 years"	"67"	85641
+	"Arizona"	"04"	"68 years"	"68"	83960
+	"Arizona"	"04"	"69 years"	"69"	82025
+	"Arizona"	"04"	"70 years"	"70"	79785
+	"Arizona"	"04"	"71 years"	"71"	77280
+	"Arizona"	"04"	"72 years"	"72"	74638
+	"Arizona"	"04"	"73 years"	"73"	72318
+	"Arizona"	"04"	"74 years"	"74"	71042
+	"Arizona"	"04"	"75 years"	"75"	70550
+	"Arizona"	"04"	"76 years"	"76"	74998
+	"Arizona"	"04"	"77 years"	"77"	52659
+	"Arizona"	"04"	"78 years"	"78"	50022
+	"Arizona"	"04"	"79 years"	"79"	48473
+	"Arizona"	"04"	"80 years"	"80"	48548
+	"Arizona"	"04"	"81 years"	"81"	40290
+	"Arizona"	"04"	"82 years"	"82"	35389
+	"Arizona"	"04"	"83 years"	"83"	31297
+	"Arizona"	"04"	"84 years"	"84"	28232
+	"Arizona"	"04"	"85+ years"	"85+"	149125
+"Total"	"Arizona"	"04"			7431344
+	"Arkansas"	"05"	"< 1 year"	"0"	35297
+	"Arkansas"	"05"	"1 year"	"1"	36502
+	"Arkansas"	"05"	"2 years"	"2"	35449
+	"Arkansas"	"05"	"3 years"	"3"	36407
+	"Arkansas"	"05"	"4 years"	"4"	37179
+	"Arkansas"	"05"	"5 years"	"5"	38183
+	"Arkansas"	"05"	"6 years"	"6"	38729
+	"Arkansas"	"05"	"7 years"	"7"	39684
+	"Arkansas"	"05"	"8 years"	"8"	39754
+	"Arkansas"	"05"	"9 years"	"9"	39392
+	"Arkansas"	"05"	"10 years"	"10"	38995
+	"Arkansas"	"05"	"11 years"	"11"	39229
+	"Arkansas"	"05"	"12 years"	"12"	39607
+	"Arkansas"	"05"	"13 years"	"13"	40428
+	"Arkansas"	"05"	"14 years"	"14"	41524
+	"Arkansas"	"05"	"15 years"	"15"	43418
+	"Arkansas"	"05"	"16 years"	"16"	43387
+	"Arkansas"	"05"	"17 years"	"17"	42444
+	"Arkansas"	"05"	"18 years"	"18"	40197
+	"Arkansas"	"05"	"19 years"	"19"	40212
+	"Arkansas"	"05"	"20 years"	"20"	41254
+	"Arkansas"	"05"	"21 years"	"21"	40853
+	"Arkansas"	"05"	"22 years"	"22"	41672
+	"Arkansas"	"05"	"23 years"	"23"	40989
+	"Arkansas"	"05"	"24 years"	"24"	40294
+	"Arkansas"	"05"	"25 years"	"25"	39681
+	"Arkansas"	"05"	"26 years"	"26"	39106
+	"Arkansas"	"05"	"27 years"	"27"	38650
+	"Arkansas"	"05"	"28 years"	"28"	38874
+	"Arkansas"	"05"	"29 years"	"29"	39083
+	"Arkansas"	"05"	"30 years"	"30"	39877
+	"Arkansas"	"05"	"31 years"	"31"	40995
+	"Arkansas"	"05"	"32 years"	"32"	42032
+	"Arkansas"	"05"	"33 years"	"33"	41804
+	"Arkansas"	"05"	"34 years"	"34"	40264
+	"Arkansas"	"05"	"35 years"	"35"	39062
+	"Arkansas"	"05"	"36 years"	"36"	38550
+	"Arkansas"	"05"	"37 years"	"37"	38495
+	"Arkansas"	"05"	"38 years"	"38"	38730
+	"Arkansas"	"05"	"39 years"	"39"	38595
+	"Arkansas"	"05"	"40 years"	"40"	38953
+	"Arkansas"	"05"	"41 years"	"41"	39350
+	"Arkansas"	"05"	"42 years"	"42"	39128
+	"Arkansas"	"05"	"43 years"	"43"	39239
+	"Arkansas"	"05"	"44 years"	"44"	37464
+	"Arkansas"	"05"	"45 years"	"45"	36578
+	"Arkansas"	"05"	"46 years"	"46"	36273
+	"Arkansas"	"05"	"47 years"	"47"	34852
+	"Arkansas"	"05"	"48 years"	"48"	35479
+	"Arkansas"	"05"	"49 years"	"49"	34830
+	"Arkansas"	"05"	"50 years"	"50"	34974
+	"Arkansas"	"05"	"51 years"	"51"	36765
+	"Arkansas"	"05"	"52 years"	"52"	38654
+	"Arkansas"	"05"	"53 years"	"53"	37774
+	"Arkansas"	"05"	"54 years"	"54"	35657
+	"Arkansas"	"05"	"55 years"	"55"	34691
+	"Arkansas"	"05"	"56 years"	"56"	35268
+	"Arkansas"	"05"	"57 years"	"57"	35456
+	"Arkansas"	"05"	"58 years"	"58"	37757
+	"Arkansas"	"05"	"59 years"	"59"	39092
+	"Arkansas"	"05"	"60 years"	"60"	39321
+	"Arkansas"	"05"	"61 years"	"61"	39306
+	"Arkansas"	"05"	"62 years"	"62"	38993
+	"Arkansas"	"05"	"63 years"	"63"	38153
+	"Arkansas"	"05"	"64 years"	"64"	37554
+	"Arkansas"	"05"	"65 years"	"65"	37036
+	"Arkansas"	"05"	"66 years"	"66"	36633
+	"Arkansas"	"05"	"67 years"	"67"	34856
+	"Arkansas"	"05"	"68 years"	"68"	34086
+	"Arkansas"	"05"	"69 years"	"69"	33073
+	"Arkansas"	"05"	"70 years"	"70"	31648
+	"Arkansas"	"05"	"71 years"	"71"	30276
+	"Arkansas"	"05"	"72 years"	"72"	28622
+	"Arkansas"	"05"	"73 years"	"73"	27183
+	"Arkansas"	"05"	"74 years"	"74"	26726
+	"Arkansas"	"05"	"75 years"	"75"	25853
+	"Arkansas"	"05"	"76 years"	"76"	27413
+	"Arkansas"	"05"	"77 years"	"77"	18912
+	"Arkansas"	"05"	"78 years"	"78"	18318
+	"Arkansas"	"05"	"79 years"	"79"	17494
+	"Arkansas"	"05"	"80 years"	"80"	17369
+	"Arkansas"	"05"	"81 years"	"81"	14493
+	"Arkansas"	"05"	"82 years"	"82"	13003
+	"Arkansas"	"05"	"83 years"	"83"	11670
+	"Arkansas"	"05"	"84 years"	"84"	10350
+	"Arkansas"	"05"	"85+ years"	"85+"	56280
+"Total"	"Arkansas"	"05"			3067732
+	"California"	"06"	"< 1 year"	"0"	415125
+	"California"	"06"	"1 year"	"1"	421432
+	"California"	"06"	"2 years"	"2"	404928
+	"California"	"06"	"3 years"	"3"	423738
+	"California"	"06"	"4 years"	"4"	432567
+	"California"	"06"	"5 years"	"5"	443800
+	"California"	"06"	"6 years"	"6"	459958
+	"California"	"06"	"7 years"	"7"	471694
+	"California"	"06"	"8 years"	"8"	479383
+	"California"	"06"	"9 years"	"9"	479294
+	"California"	"06"	"10 years"	"10"	479946
+	"California"	"06"	"11 years"	"11"	480598
+	"California"	"06"	"12 years"	"12"	488148
+	"California"	"06"	"13 years"	"13"	493791
+	"California"	"06"	"14 years"	"14"	502328
+	"California"	"06"	"15 years"	"15"	525616
+	"California"	"06"	"16 years"	"16"	525439
+	"California"	"06"	"17 years"	"17"	517884
+	"California"	"06"	"18 years"	"18"	527397
+	"California"	"06"	"19 years"	"19"	512103
+	"California"	"06"	"20 years"	"20"	504094
+	"California"	"06"	"21 years"	"21"	496946
+	"California"	"06"	"22 years"	"22"	506368
+	"California"	"06"	"23 years"	"23"	509583
+	"California"	"06"	"24 years"	"24"	505907
+	"California"	"06"	"25 years"	"25"	513813
+	"California"	"06"	"26 years"	"26"	524910
+	"California"	"06"	"27 years"	"27"	537024
+	"California"	"06"	"28 years"	"28"	551580
+	"California"	"06"	"29 years"	"29"	565913
+	"California"	"06"	"30 years"	"30"	575357
+	"California"	"06"	"31 years"	"31"	592888
+	"California"	"06"	"32 years"	"32"	609020
+	"California"	"06"	"33 years"	"33"	611332
+	"California"	"06"	"34 years"	"34"	589920
+	"California"	"06"	"35 years"	"35"	577242
+	"California"	"06"	"36 years"	"36"	563827
+	"California"	"06"	"37 years"	"37"	559517
+	"California"	"06"	"38 years"	"38"	556237
+	"California"	"06"	"39 years"	"39"	544116
+	"California"	"06"	"40 years"	"40"	548995
+	"California"	"06"	"41 years"	"41"	544277
+	"California"	"06"	"42 years"	"42"	530720
+	"California"	"06"	"43 years"	"43"	525497
+	"California"	"06"	"44 years"	"44"	499332
+	"California"	"06"	"45 years"	"45"	489925
+	"California"	"06"	"46 years"	"46"	485617
+	"California"	"06"	"47 years"	"47"	475431
+	"California"	"06"	"48 years"	"48"	479351
+	"California"	"06"	"49 years"	"49"	469511
+	"California"	"06"	"50 years"	"50"	470485
+	"California"	"06"	"51 years"	"51"	481760
+	"California"	"06"	"52 years"	"52"	504761
+	"California"	"06"	"53 years"	"53"	504538
+	"California"	"06"	"54 years"	"54"	485969
+	"California"	"06"	"55 years"	"55"	472788
+	"California"	"06"	"56 years"	"56"	463330
+	"California"	"06"	"57 years"	"57"	464162
+	"California"	"06"	"58 years"	"58"	476301
+	"California"	"06"	"59 years"	"59"	481619
+	"California"	"06"	"60 years"	"60"	477458
+	"California"	"06"	"61 years"	"61"	472327
+	"California"	"06"	"62 years"	"62"	466308
+	"California"	"06"	"63 years"	"63"	460125
+	"California"	"06"	"64 years"	"64"	441910
+	"California"	"06"	"65 years"	"65"	433425
+	"California"	"06"	"66 years"	"66"	422493
+	"California"	"06"	"67 years"	"67"	403399
+	"California"	"06"	"68 years"	"68"	393936
+	"California"	"06"	"69 years"	"69"	375822
+	"California"	"06"	"70 years"	"70"	357514
+	"California"	"06"	"71 years"	"71"	340394
+	"California"	"06"	"72 years"	"72"	323527
+	"California"	"06"	"73 years"	"73"	312660
+	"California"	"06"	"74 years"	"74"	297805
+	"California"	"06"	"75 years"	"75"	287023
+	"California"	"06"	"76 years"	"76"	294637
+	"California"	"06"	"77 years"	"77"	218368
+	"California"	"06"	"78 years"	"78"	207538
+	"California"	"06"	"79 years"	"79"	195120
+	"California"	"06"	"80 years"	"80"	188201
+	"California"	"06"	"81 years"	"81"	161458
+	"California"	"06"	"82 years"	"82"	143889
+	"California"	"06"	"83 years"	"83"	131522
+	"California"	"06"	"84 years"	"84"	118967
+	"California"	"06"	"85+ years"	"85+"	704235
+"Total"	"California"	"06"			38965193
+	"Colorado"	"08"	"< 1 year"	"0"	62168
+	"Colorado"	"08"	"1 year"	"1"	61980
+	"Colorado"	"08"	"2 years"	"2"	61343
+	"Colorado"	"08"	"3 years"	"3"	61780
+	"Colorado"	"08"	"4 years"	"4"	61688
+	"Colorado"	"08"	"5 years"	"5"	63586
+	"Colorado"	"08"	"6 years"	"6"	65256
+	"Colorado"	"08"	"7 years"	"7"	67443
+	"Colorado"	"08"	"8 years"	"8"	68138
+	"Colorado"	"08"	"9 years"	"9"	67989
+	"Colorado"	"08"	"10 years"	"10"	67505
+	"Colorado"	"08"	"11 years"	"11"	67900
+	"Colorado"	"08"	"12 years"	"12"	69490
+	"Colorado"	"08"	"13 years"	"13"	71325
+	"Colorado"	"08"	"14 years"	"14"	72367
+	"Colorado"	"08"	"15 years"	"15"	75316
+	"Colorado"	"08"	"16 years"	"16"	75217
+	"Colorado"	"08"	"17 years"	"17"	74193
+	"Colorado"	"08"	"18 years"	"18"	75957
+	"Colorado"	"08"	"19 years"	"19"	77968
+	"Colorado"	"08"	"20 years"	"20"	74487
+	"Colorado"	"08"	"21 years"	"21"	74118
+	"Colorado"	"08"	"22 years"	"22"	77411
+	"Colorado"	"08"	"23 years"	"23"	79353
+	"Colorado"	"08"	"24 years"	"24"	81236
+	"Colorado"	"08"	"25 years"	"25"	84339
+	"Colorado"	"08"	"26 years"	"26"	86943
+	"Colorado"	"08"	"27 years"	"27"	89402
+	"Colorado"	"08"	"28 years"	"28"	91224
+	"Colorado"	"08"	"29 years"	"29"	93367
+	"Colorado"	"08"	"30 years"	"30"	95387
+	"Colorado"	"08"	"31 years"	"31"	97194
+	"Colorado"	"08"	"32 years"	"32"	97224
+	"Colorado"	"08"	"33 years"	"33"	96645
+	"Colorado"	"08"	"34 years"	"34"	92378
+	"Colorado"	"08"	"35 years"	"35"	91610
+	"Colorado"	"08"	"36 years"	"36"	90330
+	"Colorado"	"08"	"37 years"	"37"	90698
+	"Colorado"	"08"	"38 years"	"38"	89270
+	"Colorado"	"08"	"39 years"	"39"	86724
+	"Colorado"	"08"	"40 years"	"40"	87001
+	"Colorado"	"08"	"41 years"	"41"	85564
+	"Colorado"	"08"	"42 years"	"42"	83673
+	"Colorado"	"08"	"43 years"	"43"	81939
+	"Colorado"	"08"	"44 years"	"44"	77577
+	"Colorado"	"08"	"45 years"	"45"	75324
+	"Colorado"	"08"	"46 years"	"46"	73461
+	"Colorado"	"08"	"47 years"	"47"	70372
+	"Colorado"	"08"	"48 years"	"48"	70628
+	"Colorado"	"08"	"49 years"	"49"	68602
+	"Colorado"	"08"	"50 years"	"50"	68168
+	"Colorado"	"08"	"51 years"	"51"	70898
+	"Colorado"	"08"	"52 years"	"52"	74587
+	"Colorado"	"08"	"53 years"	"53"	72933
+	"Colorado"	"08"	"54 years"	"54"	69294
+	"Colorado"	"08"	"55 years"	"55"	65794
+	"Colorado"	"08"	"56 years"	"56"	64005
+	"Colorado"	"08"	"57 years"	"57"	64100
+	"Colorado"	"08"	"58 years"	"58"	66702
+	"Colorado"	"08"	"59 years"	"59"	68627
+	"Colorado"	"08"	"60 years"	"60"	69263
+	"Colorado"	"08"	"61 years"	"61"	70352
+	"Colorado"	"08"	"62 years"	"62"	70627
+	"Colorado"	"08"	"63 years"	"63"	69277
+	"Colorado"	"08"	"64 years"	"64"	67878
+	"Colorado"	"08"	"65 years"	"65"	67262
+	"Colorado"	"08"	"66 years"	"66"	65799
+	"Colorado"	"08"	"67 years"	"67"	62913
+	"Colorado"	"08"	"68 years"	"68"	61490
+	"Colorado"	"08"	"69 years"	"69"	59298
+	"Colorado"	"08"	"70 years"	"70"	57328
+	"Colorado"	"08"	"71 years"	"71"	54765
+	"Colorado"	"08"	"72 years"	"72"	51625
+	"Colorado"	"08"	"73 years"	"73"	48330
+	"Colorado"	"08"	"74 years"	"74"	46234
+	"Colorado"	"08"	"75 years"	"75"	44575
+	"Colorado"	"08"	"76 years"	"76"	46324
+	"Colorado"	"08"	"77 years"	"77"	31649
+	"Colorado"	"08"	"78 years"	"78"	29477
+	"Colorado"	"08"	"79 years"	"79"	27864
+	"Colorado"	"08"	"80 years"	"80"	27043
+	"Colorado"	"08"	"81 years"	"81"	22400
+	"Colorado"	"08"	"82 years"	"82"	19406
+	"Colorado"	"08"	"83 years"	"83"	17296
+	"Colorado"	"08"	"84 years"	"84"	15654
+	"Colorado"	"08"	"85+ years"	"85+"	86283
+"Total"	"Colorado"	"08"			5877610
+	"Connecticut"	"09"	"< 1 year"	"0"	34935
+	"Connecticut"	"09"	"1 year"	"1"	36422
+	"Connecticut"	"09"	"2 years"	"2"	35490
+	"Connecticut"	"09"	"3 years"	"3"	36634
+	"Connecticut"	"09"	"4 years"	"4"	37192
+	"Connecticut"	"09"	"5 years"	"5"	38103
+	"Connecticut"	"09"	"6 years"	"6"	38459
+	"Connecticut"	"09"	"7 years"	"7"	39348
+	"Connecticut"	"09"	"8 years"	"8"	39860
+	"Connecticut"	"09"	"9 years"	"9"	39785
+	"Connecticut"	"09"	"10 years"	"10"	40014
+	"Connecticut"	"09"	"11 years"	"11"	40421
+	"Connecticut"	"09"	"12 years"	"12"	41360
+	"Connecticut"	"09"	"13 years"	"13"	42312
+	"Connecticut"	"09"	"14 years"	"14"	43763
+	"Connecticut"	"09"	"15 years"	"15"	45949
+	"Connecticut"	"09"	"16 years"	"16"	46502
+	"Connecticut"	"09"	"17 years"	"17"	46437
+	"Connecticut"	"09"	"18 years"	"18"	49584
+	"Connecticut"	"09"	"19 years"	"19"	50221
+	"Connecticut"	"09"	"20 years"	"20"	50756
+	"Connecticut"	"09"	"21 years"	"21"	49084
+	"Connecticut"	"09"	"22 years"	"22"	47176
+	"Connecticut"	"09"	"23 years"	"23"	44680
+	"Connecticut"	"09"	"24 years"	"24"	43824
+	"Connecticut"	"09"	"25 years"	"25"	43469
+	"Connecticut"	"09"	"26 years"	"26"	43592
+	"Connecticut"	"09"	"27 years"	"27"	43670
+	"Connecticut"	"09"	"28 years"	"28"	44507
+	"Connecticut"	"09"	"29 years"	"29"	45605
+	"Connecticut"	"09"	"30 years"	"30"	46112
+	"Connecticut"	"09"	"31 years"	"31"	46358
+	"Connecticut"	"09"	"32 years"	"32"	46084
+	"Connecticut"	"09"	"33 years"	"33"	46723
+	"Connecticut"	"09"	"34 years"	"34"	46452
+	"Connecticut"	"09"	"35 years"	"35"	46860
+	"Connecticut"	"09"	"36 years"	"36"	47132
+	"Connecticut"	"09"	"37 years"	"37"	47748
+	"Connecticut"	"09"	"38 years"	"38"	47458
+	"Connecticut"	"09"	"39 years"	"39"	46497
+	"Connecticut"	"09"	"40 years"	"40"	46765
+	"Connecticut"	"09"	"41 years"	"41"	46640
+	"Connecticut"	"09"	"42 years"	"42"	45640
+	"Connecticut"	"09"	"43 years"	"43"	45779
+	"Connecticut"	"09"	"44 years"	"44"	44085
+	"Connecticut"	"09"	"45 years"	"45"	43456
+	"Connecticut"	"09"	"46 years"	"46"	42801
+	"Connecticut"	"09"	"47 years"	"47"	41500
+	"Connecticut"	"09"	"48 years"	"48"	41712
+	"Connecticut"	"09"	"49 years"	"49"	41076
+	"Connecticut"	"09"	"50 years"	"50"	42132
+	"Connecticut"	"09"	"51 years"	"51"	45005
+	"Connecticut"	"09"	"52 years"	"52"	48836
+	"Connecticut"	"09"	"53 years"	"53"	49217
+	"Connecticut"	"09"	"54 years"	"54"	48339
+	"Connecticut"	"09"	"55 years"	"55"	48063
+	"Connecticut"	"09"	"56 years"	"56"	49145
+	"Connecticut"	"09"	"57 years"	"57"	50219
+	"Connecticut"	"09"	"58 years"	"58"	52191
+	"Connecticut"	"09"	"59 years"	"59"	52835
+	"Connecticut"	"09"	"60 years"	"60"	51968
+	"Connecticut"	"09"	"61 years"	"61"	51726
+	"Connecticut"	"09"	"62 years"	"62"	51492
+	"Connecticut"	"09"	"63 years"	"63"	50254
+	"Connecticut"	"09"	"64 years"	"64"	48948
+	"Connecticut"	"09"	"65 years"	"65"	48361
+	"Connecticut"	"09"	"66 years"	"66"	46736
+	"Connecticut"	"09"	"67 years"	"67"	43931
+	"Connecticut"	"09"	"68 years"	"68"	42455
+	"Connecticut"	"09"	"69 years"	"69"	40452
+	"Connecticut"	"09"	"70 years"	"70"	38417
+	"Connecticut"	"09"	"71 years"	"71"	36477
+	"Connecticut"	"09"	"72 years"	"72"	34023
+	"Connecticut"	"09"	"73 years"	"73"	32363
+	"Connecticut"	"09"	"74 years"	"74"	31500
+	"Connecticut"	"09"	"75 years"	"75"	30996
+	"Connecticut"	"09"	"76 years"	"76"	33242
+	"Connecticut"	"09"	"77 years"	"77"	23690
+	"Connecticut"	"09"	"78 years"	"78"	22366
+	"Connecticut"	"09"	"79 years"	"79"	21835
+	"Connecticut"	"09"	"80 years"	"80"	22320
+	"Connecticut"	"09"	"81 years"	"81"	18587
+	"Connecticut"	"09"	"82 years"	"82"	15825
+	"Connecticut"	"09"	"83 years"	"83"	14121
+	"Connecticut"	"09"	"84 years"	"84"	12875
+	"Connecticut"	"09"	"85+ years"	"85+"	80202
+"Total"	"Connecticut"	"09"			3617176
+	"Delaware"	"10"	"< 1 year"	"0"	10745
+	"Delaware"	"10"	"1 year"	"1"	11150
+	"Delaware"	"10"	"2 years"	"2"	10514
+	"Delaware"	"10"	"3 years"	"3"	10987
+	"Delaware"	"10"	"4 years"	"4"	11075
+	"Delaware"	"10"	"5 years"	"5"	11349
+	"Delaware"	"10"	"6 years"	"6"	11463
+	"Delaware"	"10"	"7 years"	"7"	11755
+	"Delaware"	"10"	"8 years"	"8"	11828
+	"Delaware"	"10"	"9 years"	"9"	11797
+	"Delaware"	"10"	"10 years"	"10"	11753
+	"Delaware"	"10"	"11 years"	"11"	11984
+	"Delaware"	"10"	"12 years"	"12"	12173
+	"Delaware"	"10"	"13 years"	"13"	12316
+	"Delaware"	"10"	"14 years"	"14"	12474
+	"Delaware"	"10"	"15 years"	"15"	12985
+	"Delaware"	"10"	"16 years"	"16"	12817
+	"Delaware"	"10"	"17 years"	"17"	12773
+	"Delaware"	"10"	"18 years"	"18"	13487
+	"Delaware"	"10"	"19 years"	"19"	13477
+	"Delaware"	"10"	"20 years"	"20"	12608
+	"Delaware"	"10"	"21 years"	"21"	11861
+	"Delaware"	"10"	"22 years"	"22"	11931
+	"Delaware"	"10"	"23 years"	"23"	11923
+	"Delaware"	"10"	"24 years"	"24"	11828
+	"Delaware"	"10"	"25 years"	"25"	11774
+	"Delaware"	"10"	"26 years"	"26"	11630
+	"Delaware"	"10"	"27 years"	"27"	11662
+	"Delaware"	"10"	"28 years"	"28"	12130
+	"Delaware"	"10"	"29 years"	"29"	12507
+	"Delaware"	"10"	"30 years"	"30"	12849
+	"Delaware"	"10"	"31 years"	"31"	13327
+	"Delaware"	"10"	"32 years"	"32"	13860
+	"Delaware"	"10"	"33 years"	"33"	14085
+	"Delaware"	"10"	"34 years"	"34"	13796
+	"Delaware"	"10"	"35 years"	"35"	13445
+	"Delaware"	"10"	"36 years"	"36"	13061
+	"Delaware"	"10"	"37 years"	"37"	12947
+	"Delaware"	"10"	"38 years"	"38"	12808
+	"Delaware"	"10"	"39 years"	"39"	12533
+	"Delaware"	"10"	"40 years"	"40"	12710
+	"Delaware"	"10"	"41 years"	"41"	12563
+	"Delaware"	"10"	"42 years"	"42"	12359
+	"Delaware"	"10"	"43 years"	"43"	12266
+	"Delaware"	"10"	"44 years"	"44"	12025
+	"Delaware"	"10"	"45 years"	"45"	11524
+	"Delaware"	"10"	"46 years"	"46"	11124
+	"Delaware"	"10"	"47 years"	"47"	10590
+	"Delaware"	"10"	"48 years"	"48"	10861
+	"Delaware"	"10"	"49 years"	"49"	10749
+	"Delaware"	"10"	"50 years"	"50"	11097
+	"Delaware"	"10"	"51 years"	"51"	11796
+	"Delaware"	"10"	"52 years"	"52"	12728
+	"Delaware"	"10"	"53 years"	"53"	12943
+	"Delaware"	"10"	"54 years"	"54"	12391
+	"Delaware"	"10"	"55 years"	"55"	12520
+	"Delaware"	"10"	"56 years"	"56"	12892
+	"Delaware"	"10"	"57 years"	"57"	13566
+	"Delaware"	"10"	"58 years"	"58"	14216
+	"Delaware"	"10"	"59 years"	"59"	14684
+	"Delaware"	"10"	"60 years"	"60"	14845
+	"Delaware"	"10"	"61 years"	"61"	15152
+	"Delaware"	"10"	"62 years"	"62"	15233
+	"Delaware"	"10"	"63 years"	"63"	15113
+	"Delaware"	"10"	"64 years"	"64"	15158
+	"Delaware"	"10"	"65 years"	"65"	15372
+	"Delaware"	"10"	"66 years"	"66"	15246
+	"Delaware"	"10"	"67 years"	"67"	14578
+	"Delaware"	"10"	"68 years"	"68"	14196
+	"Delaware"	"10"	"69 years"	"69"	13682
+	"Delaware"	"10"	"70 years"	"70"	13110
+	"Delaware"	"10"	"71 years"	"71"	12497
+	"Delaware"	"10"	"72 years"	"72"	11716
+	"Delaware"	"10"	"73 years"	"73"	11073
+	"Delaware"	"10"	"74 years"	"74"	10693
+	"Delaware"	"10"	"75 years"	"75"	10439
+	"Delaware"	"10"	"76 years"	"76"	11024
+	"Delaware"	"10"	"77 years"	"77"	7474
+	"Delaware"	"10"	"78 years"	"78"	7051
+	"Delaware"	"10"	"79 years"	"79"	6783
+	"Delaware"	"10"	"80 years"	"80"	6777
+	"Delaware"	"10"	"81 years"	"81"	5616
+	"Delaware"	"10"	"82 years"	"82"	4717
+	"Delaware"	"10"	"83 years"	"83"	4114
+	"Delaware"	"10"	"84 years"	"84"	3652
+	"Delaware"	"10"	"85+ years"	"85+"	19508
+"Total"	"Delaware"	"10"			1031890
+	"District of Columbia"	"11"	"< 1 year"	"0"	7791
+	"District of Columbia"	"11"	"1 year"	"1"	8039
+	"District of Columbia"	"11"	"2 years"	"2"	7846
+	"District of Columbia"	"11"	"3 years"	"3"	7449
+	"District of Columbia"	"11"	"4 years"	"4"	7461
+	"District of Columbia"	"11"	"5 years"	"5"	7682
+	"District of Columbia"	"11"	"6 years"	"6"	7580
+	"District of Columbia"	"11"	"7 years"	"7"	7545
+	"District of Columbia"	"11"	"8 years"	"8"	7570
+	"District of Columbia"	"11"	"9 years"	"9"	7116
+	"District of Columbia"	"11"	"10 years"	"10"	7107
+	"District of Columbia"	"11"	"11 years"	"11"	6958
+	"District of Columbia"	"11"	"12 years"	"12"	6734
+	"District of Columbia"	"11"	"13 years"	"13"	6169
+	"District of Columbia"	"11"	"14 years"	"14"	6007
+	"District of Columbia"	"11"	"15 years"	"15"	6008
+	"District of Columbia"	"11"	"16 years"	"16"	5849
+	"District of Columbia"	"11"	"17 years"	"17"	5681
+	"District of Columbia"	"11"	"18 years"	"18"	8702
+	"District of Columbia"	"11"	"19 years"	"19"	11492
+	"District of Columbia"	"11"	"20 years"	"20"	9793
+	"District of Columbia"	"11"	"21 years"	"21"	8408
+	"District of Columbia"	"11"	"22 years"	"22"	7820
+	"District of Columbia"	"11"	"23 years"	"23"	9676
+	"District of Columbia"	"11"	"24 years"	"24"	11964
+	"District of Columbia"	"11"	"25 years"	"25"	13358
+	"District of Columbia"	"11"	"26 years"	"26"	14219
+	"District of Columbia"	"11"	"27 years"	"27"	14246
+	"District of Columbia"	"11"	"28 years"	"28"	14775
+	"District of Columbia"	"11"	"29 years"	"29"	15023
+	"District of Columbia"	"11"	"30 years"	"30"	15048
+	"District of Columbia"	"11"	"31 years"	"31"	15205
+	"District of Columbia"	"11"	"32 years"	"32"	15273
+	"District of Columbia"	"11"	"33 years"	"33"	15201
+	"District of Columbia"	"11"	"34 years"	"34"	14369
+	"District of Columbia"	"11"	"35 years"	"35"	13852
+	"District of Columbia"	"11"	"36 years"	"36"	12999
+	"District of Columbia"	"11"	"37 years"	"37"	12675
+	"District of Columbia"	"11"	"38 years"	"38"	12134
+	"District of Columbia"	"11"	"39 years"	"39"	11395
+	"District of Columbia"	"11"	"40 years"	"40"	11190
+	"District of Columbia"	"11"	"41 years"	"41"	10751
+	"District of Columbia"	"11"	"42 years"	"42"	10005
+	"District of Columbia"	"11"	"43 years"	"43"	9623
+	"District of Columbia"	"11"	"44 years"	"44"	9087
+	"District of Columbia"	"11"	"45 years"	"45"	8440
+	"District of Columbia"	"11"	"46 years"	"46"	7912
+	"District of Columbia"	"11"	"47 years"	"47"	7236
+	"District of Columbia"	"11"	"48 years"	"48"	7006
+	"District of Columbia"	"11"	"49 years"	"49"	6714
+	"District of Columbia"	"11"	"50 years"	"50"	6790
+	"District of Columbia"	"11"	"51 years"	"51"	7053
+	"District of Columbia"	"11"	"52 years"	"52"	7262
+	"District of Columbia"	"11"	"53 years"	"53"	6925
+	"District of Columbia"	"11"	"54 years"	"54"	6652
+	"District of Columbia"	"11"	"55 years"	"55"	6435
+	"District of Columbia"	"11"	"56 years"	"56"	6302
+	"District of Columbia"	"11"	"57 years"	"57"	6299
+	"District of Columbia"	"11"	"58 years"	"58"	6512
+	"District of Columbia"	"11"	"59 years"	"59"	6598
+	"District of Columbia"	"11"	"60 years"	"60"	6527
+	"District of Columbia"	"11"	"61 years"	"61"	6438
+	"District of Columbia"	"11"	"62 years"	"62"	6196
+	"District of Columbia"	"11"	"63 years"	"63"	6215
+	"District of Columbia"	"11"	"64 years"	"64"	5853
+	"District of Columbia"	"11"	"65 years"	"65"	5791
+	"District of Columbia"	"11"	"66 years"	"66"	5601
+	"District of Columbia"	"11"	"67 years"	"67"	5592
+	"District of Columbia"	"11"	"68 years"	"68"	5499
+	"District of Columbia"	"11"	"69 years"	"69"	5312
+	"District of Columbia"	"11"	"70 years"	"70"	4958
+	"District of Columbia"	"11"	"71 years"	"71"	4696
+	"District of Columbia"	"11"	"72 years"	"72"	4598
+	"District of Columbia"	"11"	"73 years"	"73"	4447
+	"District of Columbia"	"11"	"74 years"	"74"	4201
+	"District of Columbia"	"11"	"75 years"	"75"	4063
+	"District of Columbia"	"11"	"76 years"	"76"	3982
+	"District of Columbia"	"11"	"77 years"	"77"	2957
+	"District of Columbia"	"11"	"78 years"	"78"	2886
+	"District of Columbia"	"11"	"79 years"	"79"	2784
+	"District of Columbia"	"11"	"80 years"	"80"	2639
+	"District of Columbia"	"11"	"81 years"	"81"	2290
+	"District of Columbia"	"11"	"82 years"	"82"	2043
+	"District of Columbia"	"11"	"83 years"	"83"	1883
+	"District of Columbia"	"11"	"84 years"	"84"	1724
+	"District of Columbia"	"11"	"85+ years"	"85+"	10786
+"Total"	"District of Columbia"	"11"			678972
+	"Florida"	"12"	"< 1 year"	"0"	224670
+	"Florida"	"12"	"1 year"	"1"	226359
+	"Florida"	"12"	"2 years"	"2"	217030
+	"Florida"	"12"	"3 years"	"3"	225412
+	"Florida"	"12"	"4 years"	"4"	231285
+	"Florida"	"12"	"5 years"	"5"	235655
+	"Florida"	"12"	"6 years"	"6"	239240
+	"Florida"	"12"	"7 years"	"7"	245711
+	"Florida"	"12"	"8 years"	"8"	246626
+	"Florida"	"12"	"9 years"	"9"	246024
+	"Florida"	"12"	"10 years"	"10"	244340
+	"Florida"	"12"	"11 years"	"11"	245657
+	"Florida"	"12"	"12 years"	"12"	247422
+	"Florida"	"12"	"13 years"	"13"	250609
+	"Florida"	"12"	"14 years"	"14"	255978
+	"Florida"	"12"	"15 years"	"15"	266786
+	"Florida"	"12"	"16 years"	"16"	267966
+	"Florida"	"12"	"17 years"	"17"	264073
+	"Florida"	"12"	"18 years"	"18"	257747
+	"Florida"	"12"	"19 years"	"19"	255282
+	"Florida"	"12"	"20 years"	"20"	252080
+	"Florida"	"12"	"21 years"	"21"	255588
+	"Florida"	"12"	"22 years"	"22"	262884
+	"Florida"	"12"	"23 years"	"23"	267053
+	"Florida"	"12"	"24 years"	"24"	264391
+	"Florida"	"12"	"25 years"	"25"	265853
+	"Florida"	"12"	"26 years"	"26"	266454
+	"Florida"	"12"	"27 years"	"27"	266303
+	"Florida"	"12"	"28 years"	"28"	271502
+	"Florida"	"12"	"29 years"	"29"	278052
+	"Florida"	"12"	"30 years"	"30"	283235
+	"Florida"	"12"	"31 years"	"31"	292686
+	"Florida"	"12"	"32 years"	"32"	302457
+	"Florida"	"12"	"33 years"	"33"	307410
+	"Florida"	"12"	"34 years"	"34"	300586
+	"Florida"	"12"	"35 years"	"35"	295476
+	"Florida"	"12"	"36 years"	"36"	291327
+	"Florida"	"12"	"37 years"	"37"	291177
+	"Florida"	"12"	"38 years"	"38"	290783
+	"Florida"	"12"	"39 years"	"39"	286291
+	"Florida"	"12"	"40 years"	"40"	289777
+	"Florida"	"12"	"41 years"	"41"	288631
+	"Florida"	"12"	"42 years"	"42"	284412
+	"Florida"	"12"	"43 years"	"43"	283305
+	"Florida"	"12"	"44 years"	"44"	273370
+	"Florida"	"12"	"45 years"	"45"	270800
+	"Florida"	"12"	"46 years"	"46"	269708
+	"Florida"	"12"	"47 years"	"47"	262818
+	"Florida"	"12"	"48 years"	"48"	265662
+	"Florida"	"12"	"49 years"	"49"	263224
+	"Florida"	"12"	"50 years"	"50"	270349
+	"Florida"	"12"	"51 years"	"51"	283588
+	"Florida"	"12"	"52 years"	"52"	299283
+	"Florida"	"12"	"53 years"	"53"	293729
+	"Florida"	"12"	"54 years"	"54"	282620
+	"Florida"	"12"	"55 years"	"55"	279632
+	"Florida"	"12"	"56 years"	"56"	284447
+	"Florida"	"12"	"57 years"	"57"	292486
+	"Florida"	"12"	"58 years"	"58"	306284
+	"Florida"	"12"	"59 years"	"59"	314257
+	"Florida"	"12"	"60 years"	"60"	313748
+	"Florida"	"12"	"61 years"	"61"	314589
+	"Florida"	"12"	"62 years"	"62"	313202
+	"Florida"	"12"	"63 years"	"63"	306874
+	"Florida"	"12"	"64 years"	"64"	301779
+	"Florida"	"12"	"65 years"	"65"	299701
+	"Florida"	"12"	"66 years"	"66"	296034
+	"Florida"	"12"	"67 years"	"67"	285070
+	"Florida"	"12"	"68 years"	"68"	279490
+	"Florida"	"12"	"69 years"	"69"	271987
+	"Florida"	"12"	"70 years"	"70"	262941
+	"Florida"	"12"	"71 years"	"71"	256555
+	"Florida"	"12"	"72 years"	"72"	247767
+	"Florida"	"12"	"73 years"	"73"	238544
+	"Florida"	"12"	"74 years"	"74"	235174
+	"Florida"	"12"	"75 years"	"75"	234374
+	"Florida"	"12"	"76 years"	"76"	250712
+	"Florida"	"12"	"77 years"	"77"	180320
+	"Florida"	"12"	"78 years"	"78"	172548
+	"Florida"	"12"	"79 years"	"79"	167687
+	"Florida"	"12"	"80 years"	"80"	169529
+	"Florida"	"12"	"81 years"	"81"	142845
+	"Florida"	"12"	"82 years"	"82"	126093
+	"Florida"	"12"	"83 years"	"83"	113383
+	"Florida"	"12"	"84 years"	"84"	102989
+	"Florida"	"12"	"85+ years"	"85+"	582949
+"Total"	"Florida"	"12"			22610726
+	"Georgia"	"13"	"< 1 year"	"0"	125156
+	"Georgia"	"13"	"1 year"	"1"	126779
+	"Georgia"	"13"	"2 years"	"2"	124501
+	"Georgia"	"13"	"3 years"	"3"	128393
+	"Georgia"	"13"	"4 years"	"4"	131003
+	"Georgia"	"13"	"5 years"	"5"	134728
+	"Georgia"	"13"	"6 years"	"6"	136879
+	"Georgia"	"13"	"7 years"	"7"	140364
+	"Georgia"	"13"	"8 years"	"8"	142044
+	"Georgia"	"13"	"9 years"	"9"	141553
+	"Georgia"	"13"	"10 years"	"10"	141295
+	"Georgia"	"13"	"11 years"	"11"	143091
+	"Georgia"	"13"	"12 years"	"12"	145217
+	"Georgia"	"13"	"13 years"	"13"	148562
+	"Georgia"	"13"	"14 years"	"14"	153164
+	"Georgia"	"13"	"15 years"	"15"	159647
+	"Georgia"	"13"	"16 years"	"16"	159727
+	"Georgia"	"13"	"17 years"	"17"	156578
+	"Georgia"	"13"	"18 years"	"18"	149842
+	"Georgia"	"13"	"19 years"	"19"	148074
+	"Georgia"	"13"	"20 years"	"20"	147149
+	"Georgia"	"13"	"21 years"	"21"	147555
+	"Georgia"	"13"	"22 years"	"22"	151360
+	"Georgia"	"13"	"23 years"	"23"	152618
+	"Georgia"	"13"	"24 years"	"24"	148686
+	"Georgia"	"13"	"25 years"	"25"	147671
+	"Georgia"	"13"	"26 years"	"26"	146953
+	"Georgia"	"13"	"27 years"	"27"	145964
+	"Georgia"	"13"	"28 years"	"28"	147932
+	"Georgia"	"13"	"29 years"	"29"	151121
+	"Georgia"	"13"	"30 years"	"30"	154189
+	"Georgia"	"13"	"31 years"	"31"	157224
+	"Georgia"	"13"	"32 years"	"32"	158982
+	"Georgia"	"13"	"33 years"	"33"	159636
+	"Georgia"	"13"	"34 years"	"34"	154947
+	"Georgia"	"13"	"35 years"	"35"	150741
+	"Georgia"	"13"	"36 years"	"36"	148798
+	"Georgia"	"13"	"37 years"	"37"	147837
+	"Georgia"	"13"	"38 years"	"38"	148259
+	"Georgia"	"13"	"39 years"	"39"	145090
+	"Georgia"	"13"	"40 years"	"40"	147663
+	"Georgia"	"13"	"41 years"	"41"	148057
+	"Georgia"	"13"	"42 years"	"42"	147526
+	"Georgia"	"13"	"43 years"	"43"	148266
+	"Georgia"	"13"	"44 years"	"44"	142791
+	"Georgia"	"13"	"45 years"	"45"	139056
+	"Georgia"	"13"	"46 years"	"46"	138024
+	"Georgia"	"13"	"47 years"	"47"	133168
+	"Georgia"	"13"	"48 years"	"48"	136476
+	"Georgia"	"13"	"49 years"	"49"	134870
+	"Georgia"	"13"	"50 years"	"50"	138303
+	"Georgia"	"13"	"51 years"	"51"	145007
+	"Georgia"	"13"	"52 years"	"52"	152259
+	"Georgia"	"13"	"53 years"	"53"	147304
+	"Georgia"	"13"	"54 years"	"54"	139445
+	"Georgia"	"13"	"55 years"	"55"	135101
+	"Georgia"	"13"	"56 years"	"56"	134856
+	"Georgia"	"13"	"57 years"	"57"	136032
+	"Georgia"	"13"	"58 years"	"58"	139828
+	"Georgia"	"13"	"59 years"	"59"	140063
+	"Georgia"	"13"	"60 years"	"60"	137549
+	"Georgia"	"13"	"61 years"	"61"	135649
+	"Georgia"	"13"	"62 years"	"62"	132770
+	"Georgia"	"13"	"63 years"	"63"	128942
+	"Georgia"	"13"	"64 years"	"64"	124696
+	"Georgia"	"13"	"65 years"	"65"	121623
+	"Georgia"	"13"	"66 years"	"66"	119407
+	"Georgia"	"13"	"67 years"	"67"	113222
+	"Georgia"	"13"	"68 years"	"68"	109583
+	"Georgia"	"13"	"69 years"	"69"	104302
+	"Georgia"	"13"	"70 years"	"70"	98825
+	"Georgia"	"13"	"71 years"	"71"	94838
+	"Georgia"	"13"	"72 years"	"72"	89894
+	"Georgia"	"13"	"73 years"	"73"	85763
+	"Georgia"	"13"	"74 years"	"74"	83387
+	"Georgia"	"13"	"75 years"	"75"	81130
+	"Georgia"	"13"	"76 years"	"76"	83890
+	"Georgia"	"13"	"77 years"	"77"	58519
+	"Georgia"	"13"	"78 years"	"78"	55466
+	"Georgia"	"13"	"79 years"	"79"	52398
+	"Georgia"	"13"	"80 years"	"80"	51343
+	"Georgia"	"13"	"81 years"	"81"	42337
+	"Georgia"	"13"	"82 years"	"82"	36899
+	"Georgia"	"13"	"83 years"	"83"	32865
+	"Georgia"	"13"	"84 years"	"84"	29123
+	"Georgia"	"13"	"85+ years"	"85+"	151403
+"Total"	"Georgia"	"13"			11029227
+	"Hawaii"	"15"	"< 1 year"	"0"	15147
+	"Hawaii"	"15"	"1 year"	"1"	15624
+	"Hawaii"	"15"	"2 years"	"2"	15107
+	"Hawaii"	"15"	"3 years"	"3"	15670
+	"Hawaii"	"15"	"4 years"	"4"	16102
+	"Hawaii"	"15"	"5 years"	"5"	16228
+	"Hawaii"	"15"	"6 years"	"6"	16693
+	"Hawaii"	"15"	"7 years"	"7"	17041
+	"Hawaii"	"15"	"8 years"	"8"	17115
+	"Hawaii"	"15"	"9 years"	"9"	17198
+	"Hawaii"	"15"	"10 years"	"10"	17197
+	"Hawaii"	"15"	"11 years"	"11"	17041
+	"Hawaii"	"15"	"12 years"	"12"	16914
+	"Hawaii"	"15"	"13 years"	"13"	16441
+	"Hawaii"	"15"	"14 years"	"14"	16027
+	"Hawaii"	"15"	"15 years"	"15"	16486
+	"Hawaii"	"15"	"16 years"	"16"	15942
+	"Hawaii"	"15"	"17 years"	"17"	15640
+	"Hawaii"	"15"	"18 years"	"18"	14863
+	"Hawaii"	"15"	"19 years"	"19"	14997
+	"Hawaii"	"15"	"20 years"	"20"	16347
+	"Hawaii"	"15"	"21 years"	"21"	16653
+	"Hawaii"	"15"	"22 years"	"22"	17578
+	"Hawaii"	"15"	"23 years"	"23"	17392
+	"Hawaii"	"15"	"24 years"	"24"	17582
+	"Hawaii"	"15"	"25 years"	"25"	17322
+	"Hawaii"	"15"	"26 years"	"26"	17572
+	"Hawaii"	"15"	"27 years"	"27"	17522
+	"Hawaii"	"15"	"28 years"	"28"	17789
+	"Hawaii"	"15"	"29 years"	"29"	18415
+	"Hawaii"	"15"	"30 years"	"30"	18622
+	"Hawaii"	"15"	"31 years"	"31"	19268
+	"Hawaii"	"15"	"32 years"	"32"	20114
+	"Hawaii"	"15"	"33 years"	"33"	19892
+	"Hawaii"	"15"	"34 years"	"34"	19359
+	"Hawaii"	"15"	"35 years"	"35"	19515
+	"Hawaii"	"15"	"36 years"	"36"	19584
+	"Hawaii"	"15"	"37 years"	"37"	19814
+	"Hawaii"	"15"	"38 years"	"38"	19505
+	"Hawaii"	"15"	"39 years"	"39"	19444
+	"Hawaii"	"15"	"40 years"	"40"	19683
+	"Hawaii"	"15"	"41 years"	"41"	19532
+	"Hawaii"	"15"	"42 years"	"42"	18831
+	"Hawaii"	"15"	"43 years"	"43"	18854
+	"Hawaii"	"15"	"44 years"	"44"	17867
+	"Hawaii"	"15"	"45 years"	"45"	17315
+	"Hawaii"	"15"	"46 years"	"46"	16978
+	"Hawaii"	"15"	"47 years"	"47"	16532
+	"Hawaii"	"15"	"48 years"	"48"	16379
+	"Hawaii"	"15"	"49 years"	"49"	16180
+	"Hawaii"	"15"	"50 years"	"50"	16299
+	"Hawaii"	"15"	"51 years"	"51"	16703
+	"Hawaii"	"15"	"52 years"	"52"	17588
+	"Hawaii"	"15"	"53 years"	"53"	17915
+	"Hawaii"	"15"	"54 years"	"54"	17097
+	"Hawaii"	"15"	"55 years"	"55"	16772
+	"Hawaii"	"15"	"56 years"	"56"	16498
+	"Hawaii"	"15"	"57 years"	"57"	16979
+	"Hawaii"	"15"	"58 years"	"58"	17608
+	"Hawaii"	"15"	"59 years"	"59"	17824
+	"Hawaii"	"15"	"60 years"	"60"	18214
+	"Hawaii"	"15"	"61 years"	"61"	18083
+	"Hawaii"	"15"	"62 years"	"62"	18004
+	"Hawaii"	"15"	"63 years"	"63"	18338
+	"Hawaii"	"15"	"64 years"	"64"	17797
+	"Hawaii"	"15"	"65 years"	"65"	17862
+	"Hawaii"	"15"	"66 years"	"66"	17762
+	"Hawaii"	"15"	"67 years"	"67"	17438
+	"Hawaii"	"15"	"68 years"	"68"	17294
+	"Hawaii"	"15"	"69 years"	"69"	16937
+	"Hawaii"	"15"	"70 years"	"70"	16894
+	"Hawaii"	"15"	"71 years"	"71"	16214
+	"Hawaii"	"15"	"72 years"	"72"	15363
+	"Hawaii"	"15"	"73 years"	"73"	15388
+	"Hawaii"	"15"	"74 years"	"74"	14725
+	"Hawaii"	"15"	"75 years"	"75"	14291
+	"Hawaii"	"15"	"76 years"	"76"	14182
+	"Hawaii"	"15"	"77 years"	"77"	10993
+	"Hawaii"	"15"	"78 years"	"78"	10461
+	"Hawaii"	"15"	"79 years"	"79"	9960
+	"Hawaii"	"15"	"80 years"	"80"	9021
+	"Hawaii"	"15"	"81 years"	"81"	7781
+	"Hawaii"	"15"	"82 years"	"82"	6906
+	"Hawaii"	"15"	"83 years"	"83"	6278
+	"Hawaii"	"15"	"84 years"	"84"	5554
+	"Hawaii"	"15"	"85+ years"	"85+"	41202
+"Total"	"Hawaii"	"15"			1435138
+	"Idaho"	"16"	"< 1 year"	"0"	22331
+	"Idaho"	"16"	"1 year"	"1"	22401
+	"Idaho"	"16"	"2 years"	"2"	22331
+	"Idaho"	"16"	"3 years"	"3"	23038
+	"Idaho"	"16"	"4 years"	"4"	23282
+	"Idaho"	"16"	"5 years"	"5"	24111
+	"Idaho"	"16"	"6 years"	"6"	25246
+	"Idaho"	"16"	"7 years"	"7"	26356
+	"Idaho"	"16"	"8 years"	"8"	26752
+	"Idaho"	"16"	"9 years"	"9"	26442
+	"Idaho"	"16"	"10 years"	"10"	26501
+	"Idaho"	"16"	"11 years"	"11"	26494
+	"Idaho"	"16"	"12 years"	"12"	26965
+	"Idaho"	"16"	"13 years"	"13"	27940
+	"Idaho"	"16"	"14 years"	"14"	28758
+	"Idaho"	"16"	"15 years"	"15"	29724
+	"Idaho"	"16"	"16 years"	"16"	29625
+	"Idaho"	"16"	"17 years"	"17"	29045
+	"Idaho"	"16"	"18 years"	"18"	32404
+	"Idaho"	"16"	"19 years"	"19"	30180
+	"Idaho"	"16"	"20 years"	"20"	25157
+	"Idaho"	"16"	"21 years"	"21"	25387
+	"Idaho"	"16"	"22 years"	"22"	26926
+	"Idaho"	"16"	"23 years"	"23"	27162
+	"Idaho"	"16"	"24 years"	"24"	26457
+	"Idaho"	"16"	"25 years"	"25"	25540
+	"Idaho"	"16"	"26 years"	"26"	25214
+	"Idaho"	"16"	"27 years"	"27"	24690
+	"Idaho"	"16"	"28 years"	"28"	24847
+	"Idaho"	"16"	"29 years"	"29"	25182
+	"Idaho"	"16"	"30 years"	"30"	25229
+	"Idaho"	"16"	"31 years"	"31"	25885
+	"Idaho"	"16"	"32 years"	"32"	26175
+	"Idaho"	"16"	"33 years"	"33"	26256
+	"Idaho"	"16"	"34 years"	"34"	25513
+	"Idaho"	"16"	"35 years"	"35"	25338
+	"Idaho"	"16"	"36 years"	"36"	25415
+	"Idaho"	"16"	"37 years"	"37"	25714
+	"Idaho"	"16"	"38 years"	"38"	25782
+	"Idaho"	"16"	"39 years"	"39"	25608
+	"Idaho"	"16"	"40 years"	"40"	26026
+	"Idaho"	"16"	"41 years"	"41"	26231
+	"Idaho"	"16"	"42 years"	"42"	26088
+	"Idaho"	"16"	"43 years"	"43"	26014
+	"Idaho"	"16"	"44 years"	"44"	25152
+	"Idaho"	"16"	"45 years"	"45"	24299
+	"Idaho"	"16"	"46 years"	"46"	23846
+	"Idaho"	"16"	"47 years"	"47"	22491
+	"Idaho"	"16"	"48 years"	"48"	22476
+	"Idaho"	"16"	"49 years"	"49"	21472
+	"Idaho"	"16"	"50 years"	"50"	21145
+	"Idaho"	"16"	"51 years"	"51"	21876
+	"Idaho"	"16"	"52 years"	"52"	22964
+	"Idaho"	"16"	"53 years"	"53"	22511
+	"Idaho"	"16"	"54 years"	"54"	21698
+	"Idaho"	"16"	"55 years"	"55"	21149
+	"Idaho"	"16"	"56 years"	"56"	21039
+	"Idaho"	"16"	"57 years"	"57"	21047
+	"Idaho"	"16"	"58 years"	"58"	21814
+	"Idaho"	"16"	"59 years"	"59"	22616
+	"Idaho"	"16"	"60 years"	"60"	23216
+	"Idaho"	"16"	"61 years"	"61"	23904
+	"Idaho"	"16"	"62 years"	"62"	24219
+	"Idaho"	"16"	"63 years"	"63"	23596
+	"Idaho"	"16"	"64 years"	"64"	23304
+	"Idaho"	"16"	"65 years"	"65"	23357
+	"Idaho"	"16"	"66 years"	"66"	23527
+	"Idaho"	"16"	"67 years"	"67"	22409
+	"Idaho"	"16"	"68 years"	"68"	21770
+	"Idaho"	"16"	"69 years"	"69"	21165
+	"Idaho"	"16"	"70 years"	"70"	20672
+	"Idaho"	"16"	"71 years"	"71"	19706
+	"Idaho"	"16"	"72 years"	"72"	18441
+	"Idaho"	"16"	"73 years"	"73"	17310
+	"Idaho"	"16"	"74 years"	"74"	16656
+	"Idaho"	"16"	"75 years"	"75"	16161
+	"Idaho"	"16"	"76 years"	"76"	17058
+	"Idaho"	"16"	"77 years"	"77"	11571
+	"Idaho"	"16"	"78 years"	"78"	11078
+	"Idaho"	"16"	"79 years"	"79"	10636
+	"Idaho"	"16"	"80 years"	"80"	10514
+	"Idaho"	"16"	"81 years"	"81"	8590
+	"Idaho"	"16"	"82 years"	"82"	7476
+	"Idaho"	"16"	"83 years"	"83"	6685
+	"Idaho"	"16"	"84 years"	"84"	5938
+	"Idaho"	"16"	"85+ years"	"85+"	30410
+"Total"	"Idaho"	"16"			1964726
+	"Illinois"	"17"	"< 1 year"	"0"	126792
+	"Illinois"	"17"	"1 year"	"1"	129077
+	"Illinois"	"17"	"2 years"	"2"	130714
+	"Illinois"	"17"	"3 years"	"3"	137579
+	"Illinois"	"17"	"4 years"	"4"	140712
+	"Illinois"	"17"	"5 years"	"5"	144919
+	"Illinois"	"17"	"6 years"	"6"	147917
+	"Illinois"	"17"	"7 years"	"7"	152123
+	"Illinois"	"17"	"8 years"	"8"	153215
+	"Illinois"	"17"	"9 years"	"9"	151561
+	"Illinois"	"17"	"10 years"	"10"	150936
+	"Illinois"	"17"	"11 years"	"11"	152599
+	"Illinois"	"17"	"12 years"	"12"	155267
+	"Illinois"	"17"	"13 years"	"13"	159633
+	"Illinois"	"17"	"14 years"	"14"	163033
+	"Illinois"	"17"	"15 years"	"15"	169864
+	"Illinois"	"17"	"16 years"	"16"	170587
+	"Illinois"	"17"	"17 years"	"17"	168994
+	"Illinois"	"17"	"18 years"	"18"	161904
+	"Illinois"	"17"	"19 years"	"19"	160159
+	"Illinois"	"17"	"20 years"	"20"	162147
+	"Illinois"	"17"	"21 years"	"21"	161887
+	"Illinois"	"17"	"22 years"	"22"	165026
+	"Illinois"	"17"	"23 years"	"23"	165280
+	"Illinois"	"17"	"24 years"	"24"	162028
+	"Illinois"	"17"	"25 years"	"25"	162116
+	"Illinois"	"17"	"26 years"	"26"	162747
+	"Illinois"	"17"	"27 years"	"27"	163954
+	"Illinois"	"17"	"28 years"	"28"	167842
+	"Illinois"	"17"	"29 years"	"29"	170164
+	"Illinois"	"17"	"30 years"	"30"	171779
+	"Illinois"	"17"	"31 years"	"31"	174291
+	"Illinois"	"17"	"32 years"	"32"	174708
+	"Illinois"	"17"	"33 years"	"33"	173848
+	"Illinois"	"17"	"34 years"	"34"	168954
+	"Illinois"	"17"	"35 years"	"35"	167610
+	"Illinois"	"17"	"36 years"	"36"	167020
+	"Illinois"	"17"	"37 years"	"37"	168643
+	"Illinois"	"17"	"38 years"	"38"	169898
+	"Illinois"	"17"	"39 years"	"39"	166573
+	"Illinois"	"17"	"40 years"	"40"	168884
+	"Illinois"	"17"	"41 years"	"41"	169091
+	"Illinois"	"17"	"42 years"	"42"	167438
+	"Illinois"	"17"	"43 years"	"43"	168167
+	"Illinois"	"17"	"44 years"	"44"	161233
+	"Illinois"	"17"	"45 years"	"45"	157613
+	"Illinois"	"17"	"46 years"	"46"	156080
+	"Illinois"	"17"	"47 years"	"47"	150529
+	"Illinois"	"17"	"48 years"	"48"	151397
+	"Illinois"	"17"	"49 years"	"49"	148205
+	"Illinois"	"17"	"50 years"	"50"	149379
+	"Illinois"	"17"	"51 years"	"51"	156957
+	"Illinois"	"17"	"52 years"	"52"	165384
+	"Illinois"	"17"	"53 years"	"53"	161895
+	"Illinois"	"17"	"54 years"	"54"	155392
+	"Illinois"	"17"	"55 years"	"55"	152343
+	"Illinois"	"17"	"56 years"	"56"	152670
+	"Illinois"	"17"	"57 years"	"57"	154297
+	"Illinois"	"17"	"58 years"	"58"	159200
+	"Illinois"	"17"	"59 years"	"59"	161951
+	"Illinois"	"17"	"60 years"	"60"	161979
+	"Illinois"	"17"	"61 years"	"61"	162829
+	"Illinois"	"17"	"62 years"	"62"	162933
+	"Illinois"	"17"	"63 years"	"63"	159579
+	"Illinois"	"17"	"64 years"	"64"	156242
+	"Illinois"	"17"	"65 years"	"65"	154059
+	"Illinois"	"17"	"66 years"	"66"	150459
+	"Illinois"	"17"	"67 years"	"67"	143045
+	"Illinois"	"17"	"68 years"	"68"	139392
+	"Illinois"	"17"	"69 years"	"69"	132763
+	"Illinois"	"17"	"70 years"	"70"	126055
+	"Illinois"	"17"	"71 years"	"71"	120522
+	"Illinois"	"17"	"72 years"	"72"	114477
+	"Illinois"	"17"	"73 years"	"73"	107739
+	"Illinois"	"17"	"74 years"	"74"	103376
+	"Illinois"	"17"	"75 years"	"75"	99619
+	"Illinois"	"17"	"76 years"	"76"	103689
+	"Illinois"	"17"	"77 years"	"77"	72567
+	"Illinois"	"17"	"78 years"	"78"	68442
+	"Illinois"	"17"	"79 years"	"79"	66191
+	"Illinois"	"17"	"80 years"	"80"	66801
+	"Illinois"	"17"	"81 years"	"81"	57012
+	"Illinois"	"17"	"82 years"	"82"	49984
+	"Illinois"	"17"	"83 years"	"83"	44551
+	"Illinois"	"17"	"84 years"	"84"	40568
+	"Illinois"	"17"	"85+ years"	"85+"	242611
+"Total"	"Illinois"	"17"			12549689
+	"Indiana"	"18"	"< 1 year"	"0"	79101
+	"Indiana"	"18"	"1 year"	"1"	80696
+	"Indiana"	"18"	"2 years"	"2"	78995
+	"Indiana"	"18"	"3 years"	"3"	82933
+	"Indiana"	"18"	"4 years"	"4"	83998
+	"Indiana"	"18"	"5 years"	"5"	85922
+	"Indiana"	"18"	"6 years"	"6"	86627
+	"Indiana"	"18"	"7 years"	"7"	88833
+	"Indiana"	"18"	"8 years"	"8"	89476
+	"Indiana"	"18"	"9 years"	"9"	89083
+	"Indiana"	"18"	"10 years"	"10"	88996
+	"Indiana"	"18"	"11 years"	"11"	88947
+	"Indiana"	"18"	"12 years"	"12"	89248
+	"Indiana"	"18"	"13 years"	"13"	91438
+	"Indiana"	"18"	"14 years"	"14"	93692
+	"Indiana"	"18"	"15 years"	"15"	97075
+	"Indiana"	"18"	"16 years"	"16"	96883
+	"Indiana"	"18"	"17 years"	"17"	95311
+	"Indiana"	"18"	"18 years"	"18"	88593
+	"Indiana"	"18"	"19 years"	"19"	95732
+	"Indiana"	"18"	"20 years"	"20"	97664
+	"Indiana"	"18"	"21 years"	"21"	96712
+	"Indiana"	"18"	"22 years"	"22"	97755
+	"Indiana"	"18"	"23 years"	"23"	94355
+	"Indiana"	"18"	"24 years"	"24"	90312
+	"Indiana"	"18"	"25 years"	"25"	88450
+	"Indiana"	"18"	"26 years"	"26"	88082
+	"Indiana"	"18"	"27 years"	"27"	87785
+	"Indiana"	"18"	"28 years"	"28"	88374
+	"Indiana"	"18"	"29 years"	"29"	89500
+	"Indiana"	"18"	"30 years"	"30"	91297
+	"Indiana"	"18"	"31 years"	"31"	93513
+	"Indiana"	"18"	"32 years"	"32"	93456
+	"Indiana"	"18"	"33 years"	"33"	92281
+	"Indiana"	"18"	"34 years"	"34"	88731
+	"Indiana"	"18"	"35 years"	"35"	86955
+	"Indiana"	"18"	"36 years"	"36"	85953
+	"Indiana"	"18"	"37 years"	"37"	87128
+	"Indiana"	"18"	"38 years"	"38"	87613
+	"Indiana"	"18"	"39 years"	"39"	85705
+	"Indiana"	"18"	"40 years"	"40"	87711
+	"Indiana"	"18"	"41 years"	"41"	88253
+	"Indiana"	"18"	"42 years"	"42"	87833
+	"Indiana"	"18"	"43 years"	"43"	87918
+	"Indiana"	"18"	"44 years"	"44"	85086
+	"Indiana"	"18"	"45 years"	"45"	83106
+	"Indiana"	"18"	"46 years"	"46"	81447
+	"Indiana"	"18"	"47 years"	"47"	78455
+	"Indiana"	"18"	"48 years"	"48"	79620
+	"Indiana"	"18"	"49 years"	"49"	77809
+	"Indiana"	"18"	"50 years"	"50"	79230
+	"Indiana"	"18"	"51 years"	"51"	83292
+	"Indiana"	"18"	"52 years"	"52"	88609
+	"Indiana"	"18"	"53 years"	"53"	85807
+	"Indiana"	"18"	"54 years"	"54"	81321
+	"Indiana"	"18"	"55 years"	"55"	79116
+	"Indiana"	"18"	"56 years"	"56"	80104
+	"Indiana"	"18"	"57 years"	"57"	80906
+	"Indiana"	"18"	"58 years"	"58"	84887
+	"Indiana"	"18"	"59 years"	"59"	87404
+	"Indiana"	"18"	"60 years"	"60"	86916
+	"Indiana"	"18"	"61 years"	"61"	87548
+	"Indiana"	"18"	"62 years"	"62"	87810
+	"Indiana"	"18"	"63 years"	"63"	85590
+	"Indiana"	"18"	"64 years"	"64"	84073
+	"Indiana"	"18"	"65 years"	"65"	83716
+	"Indiana"	"18"	"66 years"	"66"	81873
+	"Indiana"	"18"	"67 years"	"67"	77814
+	"Indiana"	"18"	"68 years"	"68"	75515
+	"Indiana"	"18"	"69 years"	"69"	72456
+	"Indiana"	"18"	"70 years"	"70"	69040
+	"Indiana"	"18"	"71 years"	"71"	66154
+	"Indiana"	"18"	"72 years"	"72"	61889
+	"Indiana"	"18"	"73 years"	"73"	58232
+	"Indiana"	"18"	"74 years"	"74"	56315
+	"Indiana"	"18"	"75 years"	"75"	53677
+	"Indiana"	"18"	"76 years"	"76"	56234
+	"Indiana"	"18"	"77 years"	"77"	38034
+	"Indiana"	"18"	"78 years"	"78"	36153
+	"Indiana"	"18"	"79 years"	"79"	35129
+	"Indiana"	"18"	"80 years"	"80"	35531
+	"Indiana"	"18"	"81 years"	"81"	29870
+	"Indiana"	"18"	"82 years"	"82"	26113
+	"Indiana"	"18"	"83 years"	"83"	23337
+	"Indiana"	"18"	"84 years"	"84"	21223
+	"Indiana"	"18"	"85+ years"	"85+"	120843
+"Total"	"Indiana"	"18"			6862199
+	"Iowa"	"19"	"< 1 year"	"0"	36766
+	"Iowa"	"19"	"1 year"	"1"	37162
+	"Iowa"	"19"	"2 years"	"2"	36187
+	"Iowa"	"19"	"3 years"	"3"	37882
+	"Iowa"	"19"	"4 years"	"4"	38042
+	"Iowa"	"19"	"5 years"	"5"	39240
+	"Iowa"	"19"	"6 years"	"6"	39874
+	"Iowa"	"19"	"7 years"	"7"	40879
+	"Iowa"	"19"	"8 years"	"8"	41217
+	"Iowa"	"19"	"9 years"	"9"	41181
+	"Iowa"	"19"	"10 years"	"10"	40704
+	"Iowa"	"19"	"11 years"	"11"	40368
+	"Iowa"	"19"	"12 years"	"12"	40422
+	"Iowa"	"19"	"13 years"	"13"	42127
+	"Iowa"	"19"	"14 years"	"14"	43586
+	"Iowa"	"19"	"15 years"	"15"	45158
+	"Iowa"	"19"	"16 years"	"16"	45103
+	"Iowa"	"19"	"17 years"	"17"	44224
+	"Iowa"	"19"	"18 years"	"18"	43635
+	"Iowa"	"19"	"19 years"	"19"	48521
+	"Iowa"	"19"	"20 years"	"20"	47667
+	"Iowa"	"19"	"21 years"	"21"	46861
+	"Iowa"	"19"	"22 years"	"22"	46791
+	"Iowa"	"19"	"23 years"	"23"	44001
+	"Iowa"	"19"	"24 years"	"24"	41648
+	"Iowa"	"19"	"25 years"	"25"	40199
+	"Iowa"	"19"	"26 years"	"26"	39601
+	"Iowa"	"19"	"27 years"	"27"	39009
+	"Iowa"	"19"	"28 years"	"28"	39216
+	"Iowa"	"19"	"29 years"	"29"	39849
+	"Iowa"	"19"	"30 years"	"30"	40557
+	"Iowa"	"19"	"31 years"	"31"	41113
+	"Iowa"	"19"	"32 years"	"32"	40819
+	"Iowa"	"19"	"33 years"	"33"	40519
+	"Iowa"	"19"	"34 years"	"34"	39181
+	"Iowa"	"19"	"35 years"	"35"	38409
+	"Iowa"	"19"	"36 years"	"36"	38592
+	"Iowa"	"19"	"37 years"	"37"	39858
+	"Iowa"	"19"	"38 years"	"38"	40990
+	"Iowa"	"19"	"39 years"	"39"	40451
+	"Iowa"	"19"	"40 years"	"40"	41552
+	"Iowa"	"19"	"41 years"	"41"	41895
+	"Iowa"	"19"	"42 years"	"42"	41587
+	"Iowa"	"19"	"43 years"	"43"	41378
+	"Iowa"	"19"	"44 years"	"44"	39762
+	"Iowa"	"19"	"45 years"	"45"	38217
+	"Iowa"	"19"	"46 years"	"46"	37158
+	"Iowa"	"19"	"47 years"	"47"	35137
+	"Iowa"	"19"	"48 years"	"48"	35174
+	"Iowa"	"19"	"49 years"	"49"	33802
+	"Iowa"	"19"	"50 years"	"50"	33683
+	"Iowa"	"19"	"51 years"	"51"	35935
+	"Iowa"	"19"	"52 years"	"52"	38285
+	"Iowa"	"19"	"53 years"	"53"	37654
+	"Iowa"	"19"	"54 years"	"54"	36745
+	"Iowa"	"19"	"55 years"	"55"	35744
+	"Iowa"	"19"	"56 years"	"56"	36173
+	"Iowa"	"19"	"57 years"	"57"	36884
+	"Iowa"	"19"	"58 years"	"58"	38597
+	"Iowa"	"19"	"59 years"	"59"	40163
+	"Iowa"	"19"	"60 years"	"60"	41049
+	"Iowa"	"19"	"61 years"	"61"	41978
+	"Iowa"	"19"	"62 years"	"62"	42529
+	"Iowa"	"19"	"63 years"	"63"	41593
+	"Iowa"	"19"	"64 years"	"64"	40884
+	"Iowa"	"19"	"65 years"	"65"	40365
+	"Iowa"	"19"	"66 years"	"66"	39471
+	"Iowa"	"19"	"67 years"	"67"	37823
+	"Iowa"	"19"	"68 years"	"68"	36995
+	"Iowa"	"19"	"69 years"	"69"	35771
+	"Iowa"	"19"	"70 years"	"70"	34270
+	"Iowa"	"19"	"71 years"	"71"	33230
+	"Iowa"	"19"	"72 years"	"72"	31249
+	"Iowa"	"19"	"73 years"	"73"	29045
+	"Iowa"	"19"	"74 years"	"74"	27756
+	"Iowa"	"19"	"75 years"	"75"	26631
+	"Iowa"	"19"	"76 years"	"76"	27786
+	"Iowa"	"19"	"77 years"	"77"	18832
+	"Iowa"	"19"	"78 years"	"78"	17846
+	"Iowa"	"19"	"79 years"	"79"	17481
+	"Iowa"	"19"	"80 years"	"80"	17699
+	"Iowa"	"19"	"81 years"	"81"	14895
+	"Iowa"	"19"	"82 years"	"82"	13447
+	"Iowa"	"19"	"83 years"	"83"	12348
+	"Iowa"	"19"	"84 years"	"84"	11412
+	"Iowa"	"19"	"85+ years"	"85+"	71485
+"Total"	"Iowa"	"19"			3207004
+	"Kansas"	"20"	"< 1 year"	"0"	34590
+	"Kansas"	"20"	"1 year"	"1"	34438
+	"Kansas"	"20"	"2 years"	"2"	34227
+	"Kansas"	"20"	"3 years"	"3"	35587
+	"Kansas"	"20"	"4 years"	"4"	36146
+	"Kansas"	"20"	"5 years"	"5"	36699
+	"Kansas"	"20"	"6 years"	"6"	37609
+	"Kansas"	"20"	"7 years"	"7"	38753
+	"Kansas"	"20"	"8 years"	"8"	38922
+	"Kansas"	"20"	"9 years"	"9"	39210
+	"Kansas"	"20"	"10 years"	"10"	39446
+	"Kansas"	"20"	"11 years"	"11"	39464
+	"Kansas"	"20"	"12 years"	"12"	39938
+	"Kansas"	"20"	"13 years"	"13"	40971
+	"Kansas"	"20"	"14 years"	"14"	41554
+	"Kansas"	"20"	"15 years"	"15"	42595
+	"Kansas"	"20"	"16 years"	"16"	42456
+	"Kansas"	"20"	"17 years"	"17"	41732
+	"Kansas"	"20"	"18 years"	"18"	40379
+	"Kansas"	"20"	"19 years"	"19"	43411
+	"Kansas"	"20"	"20 years"	"20"	45151
+	"Kansas"	"20"	"21 years"	"21"	43934
+	"Kansas"	"20"	"22 years"	"22"	44114
+	"Kansas"	"20"	"23 years"	"23"	42889
+	"Kansas"	"20"	"24 years"	"24"	39782
+	"Kansas"	"20"	"25 years"	"25"	38412
+	"Kansas"	"20"	"26 years"	"26"	37219
+	"Kansas"	"20"	"27 years"	"27"	37130
+	"Kansas"	"20"	"28 years"	"28"	37360
+	"Kansas"	"20"	"29 years"	"29"	37292
+	"Kansas"	"20"	"30 years"	"30"	37898
+	"Kansas"	"20"	"31 years"	"31"	38233
+	"Kansas"	"20"	"32 years"	"32"	38018
+	"Kansas"	"20"	"33 years"	"33"	37913
+	"Kansas"	"20"	"34 years"	"34"	37177
+	"Kansas"	"20"	"35 years"	"35"	37048
+	"Kansas"	"20"	"36 years"	"36"	37108
+	"Kansas"	"20"	"37 years"	"37"	38202
+	"Kansas"	"20"	"38 years"	"38"	38764
+	"Kansas"	"20"	"39 years"	"39"	38474
+	"Kansas"	"20"	"40 years"	"40"	39001
+	"Kansas"	"20"	"41 years"	"41"	39023
+	"Kansas"	"20"	"42 years"	"42"	38368
+	"Kansas"	"20"	"43 years"	"43"	37650
+	"Kansas"	"20"	"44 years"	"44"	35841
+	"Kansas"	"20"	"45 years"	"45"	34591
+	"Kansas"	"20"	"46 years"	"46"	34265
+	"Kansas"	"20"	"47 years"	"47"	32479
+	"Kansas"	"20"	"48 years"	"48"	32550
+	"Kansas"	"20"	"49 years"	"49"	31218
+	"Kansas"	"20"	"50 years"	"50"	31211
+	"Kansas"	"20"	"51 years"	"51"	32430
+	"Kansas"	"20"	"52 years"	"52"	34512
+	"Kansas"	"20"	"53 years"	"53"	33814
+	"Kansas"	"20"	"54 years"	"54"	32445
+	"Kansas"	"20"	"55 years"	"55"	31299
+	"Kansas"	"20"	"56 years"	"56"	31510
+	"Kansas"	"20"	"57 years"	"57"	32319
+	"Kansas"	"20"	"58 years"	"58"	34108
+	"Kansas"	"20"	"59 years"	"59"	35749
+	"Kansas"	"20"	"60 years"	"60"	36353
+	"Kansas"	"20"	"61 years"	"61"	36986
+	"Kansas"	"20"	"62 years"	"62"	37060
+	"Kansas"	"20"	"63 years"	"63"	36359
+	"Kansas"	"20"	"64 years"	"64"	35766
+	"Kansas"	"20"	"65 years"	"65"	35563
+	"Kansas"	"20"	"66 years"	"66"	35001
+	"Kansas"	"20"	"67 years"	"67"	33401
+	"Kansas"	"20"	"68 years"	"68"	32563
+	"Kansas"	"20"	"69 years"	"69"	31567
+	"Kansas"	"20"	"70 years"	"70"	29965
+	"Kansas"	"20"	"71 years"	"71"	28651
+	"Kansas"	"20"	"72 years"	"72"	26938
+	"Kansas"	"20"	"73 years"	"73"	25074
+	"Kansas"	"20"	"74 years"	"74"	23884
+	"Kansas"	"20"	"75 years"	"75"	22971
+	"Kansas"	"20"	"76 years"	"76"	24276
+	"Kansas"	"20"	"77 years"	"77"	16416
+	"Kansas"	"20"	"78 years"	"78"	15654
+	"Kansas"	"20"	"79 years"	"79"	15339
+	"Kansas"	"20"	"80 years"	"80"	15183
+	"Kansas"	"20"	"81 years"	"81"	12603
+	"Kansas"	"20"	"82 years"	"82"	11218
+	"Kansas"	"20"	"83 years"	"83"	10161
+	"Kansas"	"20"	"84 years"	"84"	9424
+	"Kansas"	"20"	"85+ years"	"85+"	57542
+"Total"	"Kansas"	"20"			2940546
+	"Kentucky"	"21"	"< 1 year"	"0"	52111
+	"Kentucky"	"21"	"1 year"	"1"	52584
+	"Kentucky"	"21"	"2 years"	"2"	51638
+	"Kentucky"	"21"	"3 years"	"3"	53364
+	"Kentucky"	"21"	"4 years"	"4"	54165
+	"Kentucky"	"21"	"5 years"	"5"	55237
+	"Kentucky"	"21"	"6 years"	"6"	55812
+	"Kentucky"	"21"	"7 years"	"7"	56793
+	"Kentucky"	"21"	"8 years"	"8"	57151
+	"Kentucky"	"21"	"9 years"	"9"	57094
+	"Kentucky"	"21"	"10 years"	"10"	56839
+	"Kentucky"	"21"	"11 years"	"11"	56634
+	"Kentucky"	"21"	"12 years"	"12"	56592
+	"Kentucky"	"21"	"13 years"	"13"	57852
+	"Kentucky"	"21"	"14 years"	"14"	59460
+	"Kentucky"	"21"	"15 years"	"15"	61740
+	"Kentucky"	"21"	"16 years"	"16"	61593
+	"Kentucky"	"21"	"17 years"	"17"	60236
+	"Kentucky"	"21"	"18 years"	"18"	56142
+	"Kentucky"	"21"	"19 years"	"19"	54673
+	"Kentucky"	"21"	"20 years"	"20"	56803
+	"Kentucky"	"21"	"21 years"	"21"	58045
+	"Kentucky"	"21"	"22 years"	"22"	60793
+	"Kentucky"	"21"	"23 years"	"23"	61227
+	"Kentucky"	"21"	"24 years"	"24"	59743
+	"Kentucky"	"21"	"25 years"	"25"	58850
+	"Kentucky"	"21"	"26 years"	"26"	57551
+	"Kentucky"	"21"	"27 years"	"27"	57585
+	"Kentucky"	"21"	"28 years"	"28"	58252
+	"Kentucky"	"21"	"29 years"	"29"	58949
+	"Kentucky"	"21"	"30 years"	"30"	59676
+	"Kentucky"	"21"	"31 years"	"31"	61323
+	"Kentucky"	"21"	"32 years"	"32"	62205
+	"Kentucky"	"21"	"33 years"	"33"	61842
+	"Kentucky"	"21"	"34 years"	"34"	59022
+	"Kentucky"	"21"	"35 years"	"35"	56539
+	"Kentucky"	"21"	"36 years"	"36"	55607
+	"Kentucky"	"21"	"37 years"	"37"	55492
+	"Kentucky"	"21"	"38 years"	"38"	56050
+	"Kentucky"	"21"	"39 years"	"39"	55497
+	"Kentucky"	"21"	"40 years"	"40"	56968
+	"Kentucky"	"21"	"41 years"	"41"	57328
+	"Kentucky"	"21"	"42 years"	"42"	57666
+	"Kentucky"	"21"	"43 years"	"43"	58330
+	"Kentucky"	"21"	"44 years"	"44"	56523
+	"Kentucky"	"21"	"45 years"	"45"	55574
+	"Kentucky"	"21"	"46 years"	"46"	55316
+	"Kentucky"	"21"	"47 years"	"47"	52948
+	"Kentucky"	"21"	"48 years"	"48"	53572
+	"Kentucky"	"21"	"49 years"	"49"	52822
+	"Kentucky"	"21"	"50 years"	"50"	53524
+	"Kentucky"	"21"	"51 years"	"51"	56943
+	"Kentucky"	"21"	"52 years"	"52"	60101
+	"Kentucky"	"21"	"53 years"	"53"	57760
+	"Kentucky"	"21"	"54 years"	"54"	55622
+	"Kentucky"	"21"	"55 years"	"55"	54509
+	"Kentucky"	"21"	"56 years"	"56"	55125
+	"Kentucky"	"21"	"57 years"	"57"	56022
+	"Kentucky"	"21"	"58 years"	"58"	58540
+	"Kentucky"	"21"	"59 years"	"59"	60532
+	"Kentucky"	"21"	"60 years"	"60"	59944
+	"Kentucky"	"21"	"61 years"	"61"	60091
+	"Kentucky"	"21"	"62 years"	"62"	59568
+	"Kentucky"	"21"	"63 years"	"63"	58032
+	"Kentucky"	"21"	"64 years"	"64"	57276
+	"Kentucky"	"21"	"65 years"	"65"	56711
+	"Kentucky"	"21"	"66 years"	"66"	55762
+	"Kentucky"	"21"	"67 years"	"67"	53068
+	"Kentucky"	"21"	"68 years"	"68"	51917
+	"Kentucky"	"21"	"69 years"	"69"	50050
+	"Kentucky"	"21"	"70 years"	"70"	47467
+	"Kentucky"	"21"	"71 years"	"71"	45722
+	"Kentucky"	"21"	"72 years"	"72"	43202
+	"Kentucky"	"21"	"73 years"	"73"	40734
+	"Kentucky"	"21"	"74 years"	"74"	39694
+	"Kentucky"	"21"	"75 years"	"75"	37991
+	"Kentucky"	"21"	"76 years"	"76"	40020
+	"Kentucky"	"21"	"77 years"	"77"	26752
+	"Kentucky"	"21"	"78 years"	"78"	25329
+	"Kentucky"	"21"	"79 years"	"79"	24399
+	"Kentucky"	"21"	"80 years"	"80"	24175
+	"Kentucky"	"21"	"81 years"	"81"	19927
+	"Kentucky"	"21"	"82 years"	"82"	17755
+	"Kentucky"	"21"	"83 years"	"83"	15818
+	"Kentucky"	"21"	"84 years"	"84"	14389
+	"Kentucky"	"21"	"85+ years"	"85+"	75875
+"Total"	"Kentucky"	"21"			4526154
+	"Louisiana"	"22"	"< 1 year"	"0"	55838
+	"Louisiana"	"22"	"1 year"	"1"	56006
+	"Louisiana"	"22"	"2 years"	"2"	55733
+	"Louisiana"	"22"	"3 years"	"3"	55437
+	"Louisiana"	"22"	"4 years"	"4"	56413
+	"Louisiana"	"22"	"5 years"	"5"	57869
+	"Louisiana"	"22"	"6 years"	"6"	59069
+	"Louisiana"	"22"	"7 years"	"7"	60700
+	"Louisiana"	"22"	"8 years"	"8"	60717
+	"Louisiana"	"22"	"9 years"	"9"	60103
+	"Louisiana"	"22"	"10 years"	"10"	58882
+	"Louisiana"	"22"	"11 years"	"11"	58542
+	"Louisiana"	"22"	"12 years"	"12"	58735
+	"Louisiana"	"22"	"13 years"	"13"	60271
+	"Louisiana"	"22"	"14 years"	"14"	62108
+	"Louisiana"	"22"	"15 years"	"15"	64585
+	"Louisiana"	"22"	"16 years"	"16"	64059
+	"Louisiana"	"22"	"17 years"	"17"	62082
+	"Louisiana"	"22"	"18 years"	"18"	58840
+	"Louisiana"	"22"	"19 years"	"19"	57729
+	"Louisiana"	"22"	"20 years"	"20"	57840
+	"Louisiana"	"22"	"21 years"	"21"	59257
+	"Louisiana"	"22"	"22 years"	"22"	61546
+	"Louisiana"	"22"	"23 years"	"23"	61835
+	"Louisiana"	"22"	"24 years"	"24"	59478
+	"Louisiana"	"22"	"25 years"	"25"	57657
+	"Louisiana"	"22"	"26 years"	"26"	56640
+	"Louisiana"	"22"	"27 years"	"27"	55611
+	"Louisiana"	"22"	"28 years"	"28"	56787
+	"Louisiana"	"22"	"29 years"	"29"	58557
+	"Louisiana"	"22"	"30 years"	"30"	60330
+	"Louisiana"	"22"	"31 years"	"31"	62124
+	"Louisiana"	"22"	"32 years"	"32"	64227
+	"Louisiana"	"22"	"33 years"	"33"	64079
+	"Louisiana"	"22"	"34 years"	"34"	62524
+	"Louisiana"	"22"	"35 years"	"35"	60996
+	"Louisiana"	"22"	"36 years"	"36"	60619
+	"Louisiana"	"22"	"37 years"	"37"	61301
+	"Louisiana"	"22"	"38 years"	"38"	62108
+	"Louisiana"	"22"	"39 years"	"39"	60771
+	"Louisiana"	"22"	"40 years"	"40"	61841
+	"Louisiana"	"22"	"41 years"	"41"	62057
+	"Louisiana"	"22"	"42 years"	"42"	61026
+	"Louisiana"	"22"	"43 years"	"43"	59956
+	"Louisiana"	"22"	"44 years"	"44"	56867
+	"Louisiana"	"22"	"45 years"	"45"	54914
+	"Louisiana"	"22"	"46 years"	"46"	54036
+	"Louisiana"	"22"	"47 years"	"47"	51003
+	"Louisiana"	"22"	"48 years"	"48"	50614
+	"Louisiana"	"22"	"49 years"	"49"	49425
+	"Louisiana"	"22"	"50 years"	"50"	49966
+	"Louisiana"	"22"	"51 years"	"51"	52520
+	"Louisiana"	"22"	"52 years"	"52"	55210
+	"Louisiana"	"22"	"53 years"	"53"	53973
+	"Louisiana"	"22"	"54 years"	"54"	52680
+	"Louisiana"	"22"	"55 years"	"55"	52303
+	"Louisiana"	"22"	"56 years"	"56"	53022
+	"Louisiana"	"22"	"57 years"	"57"	54319
+	"Louisiana"	"22"	"58 years"	"58"	56737
+	"Louisiana"	"22"	"59 years"	"59"	58330
+	"Louisiana"	"22"	"60 years"	"60"	58164
+	"Louisiana"	"22"	"61 years"	"61"	59004
+	"Louisiana"	"22"	"62 years"	"62"	58683
+	"Louisiana"	"22"	"63 years"	"63"	58276
+	"Louisiana"	"22"	"64 years"	"64"	57163
+	"Louisiana"	"22"	"65 years"	"65"	55988
+	"Louisiana"	"22"	"66 years"	"66"	55469
+	"Louisiana"	"22"	"67 years"	"67"	53458
+	"Louisiana"	"22"	"68 years"	"68"	52211
+	"Louisiana"	"22"	"69 years"	"69"	49648
+	"Louisiana"	"22"	"70 years"	"70"	46843
+	"Louisiana"	"22"	"71 years"	"71"	44511
+	"Louisiana"	"22"	"72 years"	"72"	42551
+	"Louisiana"	"22"	"73 years"	"73"	40017
+	"Louisiana"	"22"	"74 years"	"74"	38085
+	"Louisiana"	"22"	"75 years"	"75"	36629
+	"Louisiana"	"22"	"76 years"	"76"	38119
+	"Louisiana"	"22"	"77 years"	"77"	26322
+	"Louisiana"	"22"	"78 years"	"78"	25133
+	"Louisiana"	"22"	"79 years"	"79"	23766
+	"Louisiana"	"22"	"80 years"	"80"	23381
+	"Louisiana"	"22"	"81 years"	"81"	19476
+	"Louisiana"	"22"	"82 years"	"82"	17322
+	"Louisiana"	"22"	"83 years"	"83"	15500
+	"Louisiana"	"22"	"84 years"	"84"	13906
+	"Louisiana"	"22"	"85+ years"	"85+"	75320
+"Total"	"Louisiana"	"22"			4573749
+	"Maine"	"23"	"< 1 year"	"0"	11892
+	"Maine"	"23"	"1 year"	"1"	12068
+	"Maine"	"23"	"2 years"	"2"	11835
+	"Maine"	"23"	"3 years"	"3"	12859
+	"Maine"	"23"	"4 years"	"4"	12991
+	"Maine"	"23"	"5 years"	"5"	13043
+	"Maine"	"23"	"6 years"	"6"	13429
+	"Maine"	"23"	"7 years"	"7"	13888
+	"Maine"	"23"	"8 years"	"8"	13971
+	"Maine"	"23"	"9 years"	"9"	13972
+	"Maine"	"23"	"10 years"	"10"	13987
+	"Maine"	"23"	"11 years"	"11"	13918
+	"Maine"	"23"	"12 years"	"12"	13977
+	"Maine"	"23"	"13 years"	"13"	14648
+	"Maine"	"23"	"14 years"	"14"	15097
+	"Maine"	"23"	"15 years"	"15"	15654
+	"Maine"	"23"	"16 years"	"16"	15937
+	"Maine"	"23"	"17 years"	"17"	15886
+	"Maine"	"23"	"18 years"	"18"	16540
+	"Maine"	"23"	"19 years"	"19"	17158
+	"Maine"	"23"	"20 years"	"20"	16289
+	"Maine"	"23"	"21 years"	"21"	15454
+	"Maine"	"23"	"22 years"	"22"	15282
+	"Maine"	"23"	"23 years"	"23"	14962
+	"Maine"	"23"	"24 years"	"24"	15041
+	"Maine"	"23"	"25 years"	"25"	15229
+	"Maine"	"23"	"26 years"	"26"	15450
+	"Maine"	"23"	"27 years"	"27"	15811
+	"Maine"	"23"	"28 years"	"28"	16298
+	"Maine"	"23"	"29 years"	"29"	16872
+	"Maine"	"23"	"30 years"	"30"	17135
+	"Maine"	"23"	"31 years"	"31"	17583
+	"Maine"	"23"	"32 years"	"32"	17835
+	"Maine"	"23"	"33 years"	"33"	18324
+	"Maine"	"23"	"34 years"	"34"	18184
+	"Maine"	"23"	"35 years"	"35"	17886
+	"Maine"	"23"	"36 years"	"36"	17694
+	"Maine"	"23"	"37 years"	"37"	17931
+	"Maine"	"23"	"38 years"	"38"	17738
+	"Maine"	"23"	"39 years"	"39"	17104
+	"Maine"	"23"	"40 years"	"40"	17343
+	"Maine"	"23"	"41 years"	"41"	17161
+	"Maine"	"23"	"42 years"	"42"	16948
+	"Maine"	"23"	"43 years"	"43"	16868
+	"Maine"	"23"	"44 years"	"44"	16432
+	"Maine"	"23"	"45 years"	"45"	15976
+	"Maine"	"23"	"46 years"	"46"	15694
+	"Maine"	"23"	"47 years"	"47"	15134
+	"Maine"	"23"	"48 years"	"48"	15639
+	"Maine"	"23"	"49 years"	"49"	15531
+	"Maine"	"23"	"50 years"	"50"	16005
+	"Maine"	"23"	"51 years"	"51"	17343
+	"Maine"	"23"	"52 years"	"52"	18752
+	"Maine"	"23"	"53 years"	"53"	18553
+	"Maine"	"23"	"54 years"	"54"	18158
+	"Maine"	"23"	"55 years"	"55"	18111
+	"Maine"	"23"	"56 years"	"56"	18657
+	"Maine"	"23"	"57 years"	"57"	19102
+	"Maine"	"23"	"58 years"	"58"	20013
+	"Maine"	"23"	"59 years"	"59"	21200
+	"Maine"	"23"	"60 years"	"60"	21624
+	"Maine"	"23"	"61 years"	"61"	22045
+	"Maine"	"23"	"62 years"	"62"	22335
+	"Maine"	"23"	"63 years"	"63"	21621
+	"Maine"	"23"	"64 years"	"64"	21784
+	"Maine"	"23"	"65 years"	"65"	21988
+	"Maine"	"23"	"66 years"	"66"	21628
+	"Maine"	"23"	"67 years"	"67"	20606
+	"Maine"	"23"	"68 years"	"68"	20090
+	"Maine"	"23"	"69 years"	"69"	19675
+	"Maine"	"23"	"70 years"	"70"	19103
+	"Maine"	"23"	"71 years"	"71"	18254
+	"Maine"	"23"	"72 years"	"72"	17149
+	"Maine"	"23"	"73 years"	"73"	16131
+	"Maine"	"23"	"74 years"	"74"	15803
+	"Maine"	"23"	"75 years"	"75"	15355
+	"Maine"	"23"	"76 years"	"76"	16057
+	"Maine"	"23"	"77 years"	"77"	10643
+	"Maine"	"23"	"78 years"	"78"	10087
+	"Maine"	"23"	"79 years"	"79"	9956
+	"Maine"	"23"	"80 years"	"80"	9911
+	"Maine"	"23"	"81 years"	"81"	8055
+	"Maine"	"23"	"82 years"	"82"	6919
+	"Maine"	"23"	"83 years"	"83"	6123
+	"Maine"	"23"	"84 years"	"84"	5609
+	"Maine"	"23"	"85+ years"	"85+"	31699
+"Total"	"Maine"	"23"			1395722
+	"Maryland"	"24"	"< 1 year"	"0"	68060
+	"Maryland"	"24"	"1 year"	"1"	69378
+	"Maryland"	"24"	"2 years"	"2"	67804
+	"Maryland"	"24"	"3 years"	"3"	71747
+	"Maryland"	"24"	"4 years"	"4"	72724
+	"Maryland"	"24"	"5 years"	"5"	74179
+	"Maryland"	"24"	"6 years"	"6"	74790
+	"Maryland"	"24"	"7 years"	"7"	76399
+	"Maryland"	"24"	"8 years"	"8"	76490
+	"Maryland"	"24"	"9 years"	"9"	76125
+	"Maryland"	"24"	"10 years"	"10"	75821
+	"Maryland"	"24"	"11 years"	"11"	76354
+	"Maryland"	"24"	"12 years"	"12"	77644
+	"Maryland"	"24"	"13 years"	"13"	78832
+	"Maryland"	"24"	"14 years"	"14"	79865
+	"Maryland"	"24"	"15 years"	"15"	82947
+	"Maryland"	"24"	"16 years"	"16"	82237
+	"Maryland"	"24"	"17 years"	"17"	80520
+	"Maryland"	"24"	"18 years"	"18"	79020
+	"Maryland"	"24"	"19 years"	"19"	73902
+	"Maryland"	"24"	"20 years"	"20"	73124
+	"Maryland"	"24"	"21 years"	"21"	72775
+	"Maryland"	"24"	"22 years"	"22"	73724
+	"Maryland"	"24"	"23 years"	"23"	73983
+	"Maryland"	"24"	"24 years"	"24"	73082
+	"Maryland"	"24"	"25 years"	"25"	73313
+	"Maryland"	"24"	"26 years"	"26"	74146
+	"Maryland"	"24"	"27 years"	"27"	74596
+	"Maryland"	"24"	"28 years"	"28"	76802
+	"Maryland"	"24"	"29 years"	"29"	78925
+	"Maryland"	"24"	"30 years"	"30"	80890
+	"Maryland"	"24"	"31 years"	"31"	83118
+	"Maryland"	"24"	"32 years"	"32"	85257
+	"Maryland"	"24"	"33 years"	"33"	87190
+	"Maryland"	"24"	"34 years"	"34"	86209
+	"Maryland"	"24"	"35 years"	"35"	86111
+	"Maryland"	"24"	"36 years"	"36"	86199
+	"Maryland"	"24"	"37 years"	"37"	86422
+	"Maryland"	"24"	"38 years"	"38"	86257
+	"Maryland"	"24"	"39 years"	"39"	84579
+	"Maryland"	"24"	"40 years"	"40"	85415
+	"Maryland"	"24"	"41 years"	"41"	84957
+	"Maryland"	"24"	"42 years"	"42"	84341
+	"Maryland"	"24"	"43 years"	"43"	83705
+	"Maryland"	"24"	"44 years"	"44"	79606
+	"Maryland"	"24"	"45 years"	"45"	77286
+	"Maryland"	"24"	"46 years"	"46"	76144
+	"Maryland"	"24"	"47 years"	"47"	73034
+	"Maryland"	"24"	"48 years"	"48"	73258
+	"Maryland"	"24"	"49 years"	"49"	71480
+	"Maryland"	"24"	"50 years"	"50"	73475
+	"Maryland"	"24"	"51 years"	"51"	77754
+	"Maryland"	"24"	"52 years"	"52"	82911
+	"Maryland"	"24"	"53 years"	"53"	82111
+	"Maryland"	"24"	"54 years"	"54"	79667
+	"Maryland"	"24"	"55 years"	"55"	79326
+	"Maryland"	"24"	"56 years"	"56"	79957
+	"Maryland"	"24"	"57 years"	"57"	81764
+	"Maryland"	"24"	"58 years"	"58"	83964
+	"Maryland"	"24"	"59 years"	"59"	85426
+	"Maryland"	"24"	"60 years"	"60"	84338
+	"Maryland"	"24"	"61 years"	"61"	83075
+	"Maryland"	"24"	"62 years"	"62"	81995
+	"Maryland"	"24"	"63 years"	"63"	79808
+	"Maryland"	"24"	"64 years"	"64"	77532
+	"Maryland"	"24"	"65 years"	"65"	75508
+	"Maryland"	"24"	"66 years"	"66"	73026
+	"Maryland"	"24"	"67 years"	"67"	68721
+	"Maryland"	"24"	"68 years"	"68"	66451
+	"Maryland"	"24"	"69 years"	"69"	63458
+	"Maryland"	"24"	"70 years"	"70"	60495
+	"Maryland"	"24"	"71 years"	"71"	57611
+	"Maryland"	"24"	"72 years"	"72"	54976
+	"Maryland"	"24"	"73 years"	"73"	51959
+	"Maryland"	"24"	"74 years"	"74"	50566
+	"Maryland"	"24"	"75 years"	"75"	49462
+	"Maryland"	"24"	"76 years"	"76"	51293
+	"Maryland"	"24"	"77 years"	"77"	36255
+	"Maryland"	"24"	"78 years"	"78"	34468
+	"Maryland"	"24"	"79 years"	"79"	32664
+	"Maryland"	"24"	"80 years"	"80"	32646
+	"Maryland"	"24"	"81 years"	"81"	27778
+	"Maryland"	"24"	"82 years"	"82"	24312
+	"Maryland"	"24"	"83 years"	"83"	21652
+	"Maryland"	"24"	"84 years"	"84"	19401
+	"Maryland"	"24"	"85+ years"	"85+"	113682
+"Total"	"Maryland"	"24"			6180253
+	"Massachusetts"	"25"	"< 1 year"	"0"	69103
+	"Massachusetts"	"25"	"1 year"	"1"	69691
+	"Massachusetts"	"25"	"2 years"	"2"	66750
+	"Massachusetts"	"25"	"3 years"	"3"	68967
+	"Massachusetts"	"25"	"4 years"	"4"	69432
+	"Massachusetts"	"25"	"5 years"	"5"	71205
+	"Massachusetts"	"25"	"6 years"	"6"	72161
+	"Massachusetts"	"25"	"7 years"	"7"	73508
+	"Massachusetts"	"25"	"8 years"	"8"	74101
+	"Massachusetts"	"25"	"9 years"	"9"	74225
+	"Massachusetts"	"25"	"10 years"	"10"	74615
+	"Massachusetts"	"25"	"11 years"	"11"	75211
+	"Massachusetts"	"25"	"12 years"	"12"	76280
+	"Massachusetts"	"25"	"13 years"	"13"	77562
+	"Massachusetts"	"25"	"14 years"	"14"	79093
+	"Massachusetts"	"25"	"15 years"	"15"	82505
+	"Massachusetts"	"25"	"16 years"	"16"	83468
+	"Massachusetts"	"25"	"17 years"	"17"	83924
+	"Massachusetts"	"25"	"18 years"	"18"	96722
+	"Massachusetts"	"25"	"19 years"	"19"	105533
+	"Massachusetts"	"25"	"20 years"	"20"	101264
+	"Massachusetts"	"25"	"21 years"	"21"	97197
+	"Massachusetts"	"25"	"22 years"	"22"	95075
+	"Massachusetts"	"25"	"23 years"	"23"	92456
+	"Massachusetts"	"25"	"24 years"	"24"	92960
+	"Massachusetts"	"25"	"25 years"	"25"	94179
+	"Massachusetts"	"25"	"26 years"	"26"	94383
+	"Massachusetts"	"25"	"27 years"	"27"	95484
+	"Massachusetts"	"25"	"28 years"	"28"	96404
+	"Massachusetts"	"25"	"29 years"	"29"	97358
+	"Massachusetts"	"25"	"30 years"	"30"	98096
+	"Massachusetts"	"25"	"31 years"	"31"	97959
+	"Massachusetts"	"25"	"32 years"	"32"	98327
+	"Massachusetts"	"25"	"33 years"	"33"	99777
+	"Massachusetts"	"25"	"34 years"	"34"	98950
+	"Massachusetts"	"25"	"35 years"	"35"	98804
+	"Massachusetts"	"25"	"36 years"	"36"	97821
+	"Massachusetts"	"25"	"37 years"	"37"	96825
+	"Massachusetts"	"25"	"38 years"	"38"	95203
+	"Massachusetts"	"25"	"39 years"	"39"	91291
+	"Massachusetts"	"25"	"40 years"	"40"	91688
+	"Massachusetts"	"25"	"41 years"	"41"	90700
+	"Massachusetts"	"25"	"42 years"	"42"	88571
+	"Massachusetts"	"25"	"43 years"	"43"	87624
+	"Massachusetts"	"25"	"44 years"	"44"	85134
+	"Massachusetts"	"25"	"45 years"	"45"	83412
+	"Massachusetts"	"25"	"46 years"	"46"	81827
+	"Massachusetts"	"25"	"47 years"	"47"	79265
+	"Massachusetts"	"25"	"48 years"	"48"	80578
+	"Massachusetts"	"25"	"49 years"	"49"	79794
+	"Massachusetts"	"25"	"50 years"	"50"	81368
+	"Massachusetts"	"25"	"51 years"	"51"	85815
+	"Massachusetts"	"25"	"52 years"	"52"	92112
+	"Massachusetts"	"25"	"53 years"	"53"	92209
+	"Massachusetts"	"25"	"54 years"	"54"	90558
+	"Massachusetts"	"25"	"55 years"	"55"	90066
+	"Massachusetts"	"25"	"56 years"	"56"	91739
+	"Massachusetts"	"25"	"57 years"	"57"	93482
+	"Massachusetts"	"25"	"58 years"	"58"	96361
+	"Massachusetts"	"25"	"59 years"	"59"	97692
+	"Massachusetts"	"25"	"60 years"	"60"	97010
+	"Massachusetts"	"25"	"61 years"	"61"	96558
+	"Massachusetts"	"25"	"62 years"	"62"	95901
+	"Massachusetts"	"25"	"63 years"	"63"	93174
+	"Massachusetts"	"25"	"64 years"	"64"	91218
+	"Massachusetts"	"25"	"65 years"	"65"	90269
+	"Massachusetts"	"25"	"66 years"	"66"	87357
+	"Massachusetts"	"25"	"67 years"	"67"	82813
+	"Massachusetts"	"25"	"68 years"	"68"	80431
+	"Massachusetts"	"25"	"69 years"	"69"	76853
+	"Massachusetts"	"25"	"70 years"	"70"	73529
+	"Massachusetts"	"25"	"71 years"	"71"	70306
+	"Massachusetts"	"25"	"72 years"	"72"	66695
+	"Massachusetts"	"25"	"73 years"	"73"	62988
+	"Massachusetts"	"25"	"74 years"	"74"	61532
+	"Massachusetts"	"25"	"75 years"	"75"	60100
+	"Massachusetts"	"25"	"76 years"	"76"	63118
+	"Massachusetts"	"25"	"77 years"	"77"	43643
+	"Massachusetts"	"25"	"78 years"	"78"	41200
+	"Massachusetts"	"25"	"79 years"	"79"	39766
+	"Massachusetts"	"25"	"80 years"	"80"	39888
+	"Massachusetts"	"25"	"81 years"	"81"	33275
+	"Massachusetts"	"25"	"82 years"	"82"	28576
+	"Massachusetts"	"25"	"83 years"	"83"	25546
+	"Massachusetts"	"25"	"84 years"	"84"	23380
+	"Massachusetts"	"25"	"85+ years"	"85+"	142409
+"Total"	"Massachusetts"	"25"			7001399
+	"Michigan"	"26"	"< 1 year"	"0"	101385
+	"Michigan"	"26"	"1 year"	"1"	104476
+	"Michigan"	"26"	"2 years"	"2"	103519
+	"Michigan"	"26"	"3 years"	"3"	109751
+	"Michigan"	"26"	"4 years"	"4"	110831
+	"Michigan"	"26"	"5 years"	"5"	113724
+	"Michigan"	"26"	"6 years"	"6"	115663
+	"Michigan"	"26"	"7 years"	"7"	118401
+	"Michigan"	"26"	"8 years"	"8"	119442
+	"Michigan"	"26"	"9 years"	"9"	119310
+	"Michigan"	"26"	"10 years"	"10"	118441
+	"Michigan"	"26"	"11 years"	"11"	118518
+	"Michigan"	"26"	"12 years"	"12"	119734
+	"Michigan"	"26"	"13 years"	"13"	122825
+	"Michigan"	"26"	"14 years"	"14"	125117
+	"Michigan"	"26"	"15 years"	"15"	130062
+	"Michigan"	"26"	"16 years"	"16"	130625
+	"Michigan"	"26"	"17 years"	"17"	130087
+	"Michigan"	"26"	"18 years"	"18"	129595
+	"Michigan"	"26"	"19 years"	"19"	126741
+	"Michigan"	"26"	"20 years"	"20"	130740
+	"Michigan"	"26"	"21 years"	"21"	133739
+	"Michigan"	"26"	"22 years"	"22"	136850
+	"Michigan"	"26"	"23 years"	"23"	135443
+	"Michigan"	"26"	"24 years"	"24"	129999
+	"Michigan"	"26"	"25 years"	"25"	126979
+	"Michigan"	"26"	"26 years"	"26"	125446
+	"Michigan"	"26"	"27 years"	"27"	125533
+	"Michigan"	"26"	"28 years"	"28"	128654
+	"Michigan"	"26"	"29 years"	"29"	131890
+	"Michigan"	"26"	"30 years"	"30"	133845
+	"Michigan"	"26"	"31 years"	"31"	137175
+	"Michigan"	"26"	"32 years"	"32"	140432
+	"Michigan"	"26"	"33 years"	"33"	138681
+	"Michigan"	"26"	"34 years"	"34"	130321
+	"Michigan"	"26"	"35 years"	"35"	125198
+	"Michigan"	"26"	"36 years"	"36"	122455
+	"Michigan"	"26"	"37 years"	"37"	122772
+	"Michigan"	"26"	"38 years"	"38"	123396
+	"Michigan"	"26"	"39 years"	"39"	120576
+	"Michigan"	"26"	"40 years"	"40"	122892
+	"Michigan"	"26"	"41 years"	"41"	123191
+	"Michigan"	"26"	"42 years"	"42"	122527
+	"Michigan"	"26"	"43 years"	"43"	122356
+	"Michigan"	"26"	"44 years"	"44"	119044
+	"Michigan"	"26"	"45 years"	"45"	116405
+	"Michigan"	"26"	"46 years"	"46"	114624
+	"Michigan"	"26"	"47 years"	"47"	110421
+	"Michigan"	"26"	"48 years"	"48"	112556
+	"Michigan"	"26"	"49 years"	"49"	111571
+	"Michigan"	"26"	"50 years"	"50"	115170
+	"Michigan"	"26"	"51 years"	"51"	123201
+	"Michigan"	"26"	"52 years"	"52"	132909
+	"Michigan"	"26"	"53 years"	"53"	130449
+	"Michigan"	"26"	"54 years"	"54"	126029
+	"Michigan"	"26"	"55 years"	"55"	124223
+	"Michigan"	"26"	"56 years"	"56"	126313
+	"Michigan"	"26"	"57 years"	"57"	127943
+	"Michigan"	"26"	"58 years"	"58"	132812
+	"Michigan"	"26"	"59 years"	"59"	137441
+	"Michigan"	"26"	"60 years"	"60"	138026
+	"Michigan"	"26"	"61 years"	"61"	139353
+	"Michigan"	"26"	"62 years"	"62"	139829
+	"Michigan"	"26"	"63 years"	"63"	136691
+	"Michigan"	"26"	"64 years"	"64"	136162
+	"Michigan"	"26"	"65 years"	"65"	136568
+	"Michigan"	"26"	"66 years"	"66"	134121
+	"Michigan"	"26"	"67 years"	"67"	127239
+	"Michigan"	"26"	"68 years"	"68"	123470
+	"Michigan"	"26"	"69 years"	"69"	118966
+	"Michigan"	"26"	"70 years"	"70"	113675
+	"Michigan"	"26"	"71 years"	"71"	109511
+	"Michigan"	"26"	"72 years"	"72"	103026
+	"Michigan"	"26"	"73 years"	"73"	95557
+	"Michigan"	"26"	"74 years"	"74"	92315
+	"Michigan"	"26"	"75 years"	"75"	88973
+	"Michigan"	"26"	"76 years"	"76"	92806
+	"Michigan"	"26"	"77 years"	"77"	62989
+	"Michigan"	"26"	"78 years"	"78"	59390
+	"Michigan"	"26"	"79 years"	"79"	57634
+	"Michigan"	"26"	"80 years"	"80"	59117
+	"Michigan"	"26"	"81 years"	"81"	49630
+	"Michigan"	"26"	"82 years"	"82"	42759
+	"Michigan"	"26"	"83 years"	"83"	37307
+	"Michigan"	"26"	"84 years"	"84"	33725
+	"Michigan"	"26"	"85+ years"	"85+"	187974
+"Total"	"Michigan"	"26"			10037261
+	"Minnesota"	"27"	"< 1 year"	"0"	63637
+	"Minnesota"	"27"	"1 year"	"1"	65087
+	"Minnesota"	"27"	"2 years"	"2"	63796
+	"Minnesota"	"27"	"3 years"	"3"	67484
+	"Minnesota"	"27"	"4 years"	"4"	68426
+	"Minnesota"	"27"	"5 years"	"5"	69818
+	"Minnesota"	"27"	"6 years"	"6"	71804
+	"Minnesota"	"27"	"7 years"	"7"	73529
+	"Minnesota"	"27"	"8 years"	"8"	74067
+	"Minnesota"	"27"	"9 years"	"9"	73965
+	"Minnesota"	"27"	"10 years"	"10"	73535
+	"Minnesota"	"27"	"11 years"	"11"	73429
+	"Minnesota"	"27"	"12 years"	"12"	73459
+	"Minnesota"	"27"	"13 years"	"13"	75296
+	"Minnesota"	"27"	"14 years"	"14"	76956
+	"Minnesota"	"27"	"15 years"	"15"	79558
+	"Minnesota"	"27"	"16 years"	"16"	79223
+	"Minnesota"	"27"	"17 years"	"17"	77865
+	"Minnesota"	"27"	"18 years"	"18"	73879
+	"Minnesota"	"27"	"19 years"	"19"	73942
+	"Minnesota"	"27"	"20 years"	"20"	73130
+	"Minnesota"	"27"	"21 years"	"21"	71981
+	"Minnesota"	"27"	"22 years"	"22"	73188
+	"Minnesota"	"27"	"23 years"	"23"	71016
+	"Minnesota"	"27"	"24 years"	"24"	69657
+	"Minnesota"	"27"	"25 years"	"25"	69256
+	"Minnesota"	"27"	"26 years"	"26"	70234
+	"Minnesota"	"27"	"27 years"	"27"	70815
+	"Minnesota"	"27"	"28 years"	"28"	72593
+	"Minnesota"	"27"	"29 years"	"29"	74383
+	"Minnesota"	"27"	"30 years"	"30"	75154
+	"Minnesota"	"27"	"31 years"	"31"	76418
+	"Minnesota"	"27"	"32 years"	"32"	76142
+	"Minnesota"	"27"	"33 years"	"33"	76621
+	"Minnesota"	"27"	"34 years"	"34"	76514
+	"Minnesota"	"27"	"35 years"	"35"	76925
+	"Minnesota"	"27"	"36 years"	"36"	77652
+	"Minnesota"	"27"	"37 years"	"37"	79403
+	"Minnesota"	"27"	"38 years"	"38"	80203
+	"Minnesota"	"27"	"39 years"	"39"	78715
+	"Minnesota"	"27"	"40 years"	"40"	79871
+	"Minnesota"	"27"	"41 years"	"41"	79875
+	"Minnesota"	"27"	"42 years"	"42"	78502
+	"Minnesota"	"27"	"43 years"	"43"	77060
+	"Minnesota"	"27"	"44 years"	"44"	73270
+	"Minnesota"	"27"	"45 years"	"45"	70144
+	"Minnesota"	"27"	"46 years"	"46"	67675
+	"Minnesota"	"27"	"47 years"	"47"	64247
+	"Minnesota"	"27"	"48 years"	"48"	64227
+	"Minnesota"	"27"	"49 years"	"49"	61618
+	"Minnesota"	"27"	"50 years"	"50"	61600
+	"Minnesota"	"27"	"51 years"	"51"	64917
+	"Minnesota"	"27"	"52 years"	"52"	70100
+	"Minnesota"	"27"	"53 years"	"53"	69719
+	"Minnesota"	"27"	"54 years"	"54"	67590
+	"Minnesota"	"27"	"55 years"	"55"	66002
+	"Minnesota"	"27"	"56 years"	"56"	66635
+	"Minnesota"	"27"	"57 years"	"57"	68308
+	"Minnesota"	"27"	"58 years"	"58"	71619
+	"Minnesota"	"27"	"59 years"	"59"	74337
+	"Minnesota"	"27"	"60 years"	"60"	75615
+	"Minnesota"	"27"	"61 years"	"61"	76713
+	"Minnesota"	"27"	"62 years"	"62"	77221
+	"Minnesota"	"27"	"63 years"	"63"	75445
+	"Minnesota"	"27"	"64 years"	"64"	73603
+	"Minnesota"	"27"	"65 years"	"65"	72380
+	"Minnesota"	"27"	"66 years"	"66"	70084
+	"Minnesota"	"27"	"67 years"	"67"	66354
+	"Minnesota"	"27"	"68 years"	"68"	64355
+	"Minnesota"	"27"	"69 years"	"69"	62131
+	"Minnesota"	"27"	"70 years"	"70"	59515
+	"Minnesota"	"27"	"71 years"	"71"	57374
+	"Minnesota"	"27"	"72 years"	"72"	53601
+	"Minnesota"	"27"	"73 years"	"73"	49932
+	"Minnesota"	"27"	"74 years"	"74"	47417
+	"Minnesota"	"27"	"75 years"	"75"	45273
+	"Minnesota"	"27"	"76 years"	"76"	47059
+	"Minnesota"	"27"	"77 years"	"77"	32090
+	"Minnesota"	"27"	"78 years"	"78"	30950
+	"Minnesota"	"27"	"79 years"	"79"	30143
+	"Minnesota"	"27"	"80 years"	"80"	30497
+	"Minnesota"	"27"	"81 years"	"81"	25649
+	"Minnesota"	"27"	"82 years"	"82"	22707
+	"Minnesota"	"27"	"83 years"	"83"	20656
+	"Minnesota"	"27"	"84 years"	"84"	18967
+	"Minnesota"	"27"	"85+ years"	"85+"	116113
+"Total"	"Minnesota"	"27"			5737915
+	"Mississippi"	"28"	"< 1 year"	"0"	34372
+	"Mississippi"	"28"	"1 year"	"1"	34415
+	"Mississippi"	"28"	"2 years"	"2"	34674
+	"Mississippi"	"28"	"3 years"	"3"	35015
+	"Mississippi"	"28"	"4 years"	"4"	35394
+	"Mississippi"	"28"	"5 years"	"5"	36036
+	"Mississippi"	"28"	"6 years"	"6"	36060
+	"Mississippi"	"28"	"7 years"	"7"	36989
+	"Mississippi"	"28"	"8 years"	"8"	37105
+	"Mississippi"	"28"	"9 years"	"9"	37104
+	"Mississippi"	"28"	"10 years"	"10"	36911
+	"Mississippi"	"28"	"11 years"	"11"	37531
+	"Mississippi"	"28"	"12 years"	"12"	37865
+	"Mississippi"	"28"	"13 years"	"13"	39242
+	"Mississippi"	"28"	"14 years"	"14"	41334
+	"Mississippi"	"28"	"15 years"	"15"	43566
+	"Mississippi"	"28"	"16 years"	"16"	43972
+	"Mississippi"	"28"	"17 years"	"17"	42241
+	"Mississippi"	"28"	"18 years"	"18"	40725
+	"Mississippi"	"28"	"19 years"	"19"	41926
+	"Mississippi"	"28"	"20 years"	"20"	40445
+	"Mississippi"	"28"	"21 years"	"21"	40112
+	"Mississippi"	"28"	"22 years"	"22"	41304
+	"Mississippi"	"28"	"23 years"	"23"	40746
+	"Mississippi"	"28"	"24 years"	"24"	38273
+	"Mississippi"	"28"	"25 years"	"25"	37177
+	"Mississippi"	"28"	"26 years"	"26"	36009
+	"Mississippi"	"28"	"27 years"	"27"	35750
+	"Mississippi"	"28"	"28 years"	"28"	36341
+	"Mississippi"	"28"	"29 years"	"29"	37290
+	"Mississippi"	"28"	"30 years"	"30"	38134
+	"Mississippi"	"28"	"31 years"	"31"	38918
+	"Mississippi"	"28"	"32 years"	"32"	39408
+	"Mississippi"	"28"	"33 years"	"33"	39098
+	"Mississippi"	"28"	"34 years"	"34"	37512
+	"Mississippi"	"28"	"35 years"	"35"	35759
+	"Mississippi"	"28"	"36 years"	"36"	35344
+	"Mississippi"	"28"	"37 years"	"37"	35815
+	"Mississippi"	"28"	"38 years"	"38"	36310
+	"Mississippi"	"28"	"39 years"	"39"	35904
+	"Mississippi"	"28"	"40 years"	"40"	36867
+	"Mississippi"	"28"	"41 years"	"41"	37581
+	"Mississippi"	"28"	"42 years"	"42"	37521
+	"Mississippi"	"28"	"43 years"	"43"	37605
+	"Mississippi"	"28"	"44 years"	"44"	36061
+	"Mississippi"	"28"	"45 years"	"45"	35193
+	"Mississippi"	"28"	"46 years"	"46"	35108
+	"Mississippi"	"28"	"47 years"	"47"	33646
+	"Mississippi"	"28"	"48 years"	"48"	33878
+	"Mississippi"	"28"	"49 years"	"49"	33384
+	"Mississippi"	"28"	"50 years"	"50"	34099
+	"Mississippi"	"28"	"51 years"	"51"	36051
+	"Mississippi"	"28"	"52 years"	"52"	38062
+	"Mississippi"	"28"	"53 years"	"53"	36862
+	"Mississippi"	"28"	"54 years"	"54"	35048
+	"Mississippi"	"28"	"55 years"	"55"	34466
+	"Mississippi"	"28"	"56 years"	"56"	34494
+	"Mississippi"	"28"	"57 years"	"57"	35062
+	"Mississippi"	"28"	"58 years"	"58"	36980
+	"Mississippi"	"28"	"59 years"	"59"	37805
+	"Mississippi"	"28"	"60 years"	"60"	37695
+	"Mississippi"	"28"	"61 years"	"61"	38152
+	"Mississippi"	"28"	"62 years"	"62"	38083
+	"Mississippi"	"28"	"63 years"	"63"	37478
+	"Mississippi"	"28"	"64 years"	"64"	36721
+	"Mississippi"	"28"	"65 years"	"65"	36005
+	"Mississippi"	"28"	"66 years"	"66"	35673
+	"Mississippi"	"28"	"67 years"	"67"	34131
+	"Mississippi"	"28"	"68 years"	"68"	33269
+	"Mississippi"	"28"	"69 years"	"69"	31908
+	"Mississippi"	"28"	"70 years"	"70"	30129
+	"Mississippi"	"28"	"71 years"	"71"	28839
+	"Mississippi"	"28"	"72 years"	"72"	27690
+	"Mississippi"	"28"	"73 years"	"73"	25982
+	"Mississippi"	"28"	"74 years"	"74"	24967
+	"Mississippi"	"28"	"75 years"	"75"	24144
+	"Mississippi"	"28"	"76 years"	"76"	25305
+	"Mississippi"	"28"	"77 years"	"77"	17322
+	"Mississippi"	"28"	"78 years"	"78"	16458
+	"Mississippi"	"28"	"79 years"	"79"	15563
+	"Mississippi"	"28"	"80 years"	"80"	15312
+	"Mississippi"	"28"	"81 years"	"81"	12923
+	"Mississippi"	"28"	"82 years"	"82"	11564
+	"Mississippi"	"28"	"83 years"	"83"	10456
+	"Mississippi"	"28"	"84 years"	"84"	9388
+	"Mississippi"	"28"	"85+ years"	"85+"	50634
+"Total"	"Mississippi"	"28"			2939690
+	"Missouri"	"29"	"< 1 year"	"0"	67996
+	"Missouri"	"29"	"1 year"	"1"	69034
+	"Missouri"	"29"	"2 years"	"2"	69108
+	"Missouri"	"29"	"3 years"	"3"	72241
+	"Missouri"	"29"	"4 years"	"4"	73138
+	"Missouri"	"29"	"5 years"	"5"	74514
+	"Missouri"	"29"	"6 years"	"6"	75080
+	"Missouri"	"29"	"7 years"	"7"	76712
+	"Missouri"	"29"	"8 years"	"8"	77212
+	"Missouri"	"29"	"9 years"	"9"	77209
+	"Missouri"	"29"	"10 years"	"10"	76495
+	"Missouri"	"29"	"11 years"	"11"	76723
+	"Missouri"	"29"	"12 years"	"12"	77606
+	"Missouri"	"29"	"13 years"	"13"	79189
+	"Missouri"	"29"	"14 years"	"14"	81219
+	"Missouri"	"29"	"15 years"	"15"	84114
+	"Missouri"	"29"	"16 years"	"16"	84156
+	"Missouri"	"29"	"17 years"	"17"	82724
+	"Missouri"	"29"	"18 years"	"18"	77692
+	"Missouri"	"29"	"19 years"	"19"	80305
+	"Missouri"	"29"	"20 years"	"20"	80761
+	"Missouri"	"29"	"21 years"	"21"	80976
+	"Missouri"	"29"	"22 years"	"22"	82639
+	"Missouri"	"29"	"23 years"	"23"	81838
+	"Missouri"	"29"	"24 years"	"24"	79824
+	"Missouri"	"29"	"25 years"	"25"	79161
+	"Missouri"	"29"	"26 years"	"26"	78605
+	"Missouri"	"29"	"27 years"	"27"	78172
+	"Missouri"	"29"	"28 years"	"28"	78821
+	"Missouri"	"29"	"29 years"	"29"	80514
+	"Missouri"	"29"	"30 years"	"30"	81966
+	"Missouri"	"29"	"31 years"	"31"	84542
+	"Missouri"	"29"	"32 years"	"32"	85295
+	"Missouri"	"29"	"33 years"	"33"	84422
+	"Missouri"	"29"	"34 years"	"34"	81169
+	"Missouri"	"29"	"35 years"	"35"	79624
+	"Missouri"	"29"	"36 years"	"36"	79766
+	"Missouri"	"29"	"37 years"	"37"	81040
+	"Missouri"	"29"	"38 years"	"38"	81266
+	"Missouri"	"29"	"39 years"	"39"	79488
+	"Missouri"	"29"	"40 years"	"40"	81175
+	"Missouri"	"29"	"41 years"	"41"	80962
+	"Missouri"	"29"	"42 years"	"42"	80258
+	"Missouri"	"29"	"43 years"	"43"	79630
+	"Missouri"	"29"	"44 years"	"44"	76017
+	"Missouri"	"29"	"45 years"	"45"	73973
+	"Missouri"	"29"	"46 years"	"46"	72264
+	"Missouri"	"29"	"47 years"	"47"	68680
+	"Missouri"	"29"	"48 years"	"48"	69435
+	"Missouri"	"29"	"49 years"	"49"	67833
+	"Missouri"	"29"	"50 years"	"50"	68583
+	"Missouri"	"29"	"51 years"	"51"	72860
+	"Missouri"	"29"	"52 years"	"52"	77713
+	"Missouri"	"29"	"53 years"	"53"	75975
+	"Missouri"	"29"	"54 years"	"54"	72539
+	"Missouri"	"29"	"55 years"	"55"	70597
+	"Missouri"	"29"	"56 years"	"56"	71871
+	"Missouri"	"29"	"57 years"	"57"	73512
+	"Missouri"	"29"	"58 years"	"58"	77885
+	"Missouri"	"29"	"59 years"	"59"	81085
+	"Missouri"	"29"	"60 years"	"60"	82620
+	"Missouri"	"29"	"61 years"	"61"	84074
+	"Missouri"	"29"	"62 years"	"62"	84490
+	"Missouri"	"29"	"63 years"	"63"	82329
+	"Missouri"	"29"	"64 years"	"64"	80825
+	"Missouri"	"29"	"65 years"	"65"	79502
+	"Missouri"	"29"	"66 years"	"66"	78056
+	"Missouri"	"29"	"67 years"	"67"	74181
+	"Missouri"	"29"	"68 years"	"68"	71512
+	"Missouri"	"29"	"69 years"	"69"	68652
+	"Missouri"	"29"	"70 years"	"70"	65105
+	"Missouri"	"29"	"71 years"	"71"	62636
+	"Missouri"	"29"	"72 years"	"72"	59140
+	"Missouri"	"29"	"73 years"	"73"	55483
+	"Missouri"	"29"	"74 years"	"74"	53559
+	"Missouri"	"29"	"75 years"	"75"	51738
+	"Missouri"	"29"	"76 years"	"76"	54704
+	"Missouri"	"29"	"77 years"	"77"	37292
+	"Missouri"	"29"	"78 years"	"78"	35749
+	"Missouri"	"29"	"79 years"	"79"	34804
+	"Missouri"	"29"	"80 years"	"80"	34988
+	"Missouri"	"29"	"81 years"	"81"	29484
+	"Missouri"	"29"	"82 years"	"82"	25891
+	"Missouri"	"29"	"83 years"	"83"	22931
+	"Missouri"	"29"	"84 years"	"84"	20984
+	"Missouri"	"29"	"85+ years"	"85+"	120224
+"Total"	"Missouri"	"29"			6196156
+	"Montana"	"30"	"< 1 year"	"0"	11266
+	"Montana"	"30"	"1 year"	"1"	11357
+	"Montana"	"30"	"2 years"	"2"	11147
+	"Montana"	"30"	"3 years"	"3"	11784
+	"Montana"	"30"	"4 years"	"4"	12020
+	"Montana"	"30"	"5 years"	"5"	12372
+	"Montana"	"30"	"6 years"	"6"	12894
+	"Montana"	"30"	"7 years"	"7"	13554
+	"Montana"	"30"	"8 years"	"8"	13686
+	"Montana"	"30"	"9 years"	"9"	13553
+	"Montana"	"30"	"10 years"	"10"	13457
+	"Montana"	"30"	"11 years"	"11"	13617
+	"Montana"	"30"	"12 years"	"12"	13462
+	"Montana"	"30"	"13 years"	"13"	13753
+	"Montana"	"30"	"14 years"	"14"	14137
+	"Montana"	"30"	"15 years"	"15"	14655
+	"Montana"	"30"	"16 years"	"16"	14646
+	"Montana"	"30"	"17 years"	"17"	14291
+	"Montana"	"30"	"18 years"	"18"	13171
+	"Montana"	"30"	"19 years"	"19"	13844
+	"Montana"	"30"	"20 years"	"20"	14222
+	"Montana"	"30"	"21 years"	"21"	14739
+	"Montana"	"30"	"22 years"	"22"	15505
+	"Montana"	"30"	"23 years"	"23"	15624
+	"Montana"	"30"	"24 years"	"24"	14932
+	"Montana"	"30"	"25 years"	"25"	14603
+	"Montana"	"30"	"26 years"	"26"	14248
+	"Montana"	"30"	"27 years"	"27"	14245
+	"Montana"	"30"	"28 years"	"28"	14447
+	"Montana"	"30"	"29 years"	"29"	14608
+	"Montana"	"30"	"30 years"	"30"	15018
+	"Montana"	"30"	"31 years"	"31"	15331
+	"Montana"	"30"	"32 years"	"32"	15486
+	"Montana"	"30"	"33 years"	"33"	15264
+	"Montana"	"30"	"34 years"	"34"	14897
+	"Montana"	"30"	"35 years"	"35"	14723
+	"Montana"	"30"	"36 years"	"36"	14591
+	"Montana"	"30"	"37 years"	"37"	14598
+	"Montana"	"30"	"38 years"	"38"	14808
+	"Montana"	"30"	"39 years"	"39"	14822
+	"Montana"	"30"	"40 years"	"40"	15120
+	"Montana"	"30"	"41 years"	"41"	15085
+	"Montana"	"30"	"42 years"	"42"	14830
+	"Montana"	"30"	"43 years"	"43"	14716
+	"Montana"	"30"	"44 years"	"44"	14037
+	"Montana"	"30"	"45 years"	"45"	13654
+	"Montana"	"30"	"46 years"	"46"	13173
+	"Montana"	"30"	"47 years"	"47"	12495
+	"Montana"	"30"	"48 years"	"48"	12265
+	"Montana"	"30"	"49 years"	"49"	11724
+	"Montana"	"30"	"50 years"	"50"	11962
+	"Montana"	"30"	"51 years"	"51"	12220
+	"Montana"	"30"	"52 years"	"52"	13266
+	"Montana"	"30"	"53 years"	"53"	12842
+	"Montana"	"30"	"54 years"	"54"	12482
+	"Montana"	"30"	"55 years"	"55"	12105
+	"Montana"	"30"	"56 years"	"56"	12211
+	"Montana"	"30"	"57 years"	"57"	12533
+	"Montana"	"30"	"58 years"	"58"	13414
+	"Montana"	"30"	"59 years"	"59"	14278
+	"Montana"	"30"	"60 years"	"60"	14694
+	"Montana"	"30"	"61 years"	"61"	15415
+	"Montana"	"30"	"62 years"	"62"	15579
+	"Montana"	"30"	"63 years"	"63"	15644
+	"Montana"	"30"	"64 years"	"64"	15707
+	"Montana"	"30"	"65 years"	"65"	15839
+	"Montana"	"30"	"66 years"	"66"	15712
+	"Montana"	"30"	"67 years"	"67"	15099
+	"Montana"	"30"	"68 years"	"68"	14893
+	"Montana"	"30"	"69 years"	"69"	14714
+	"Montana"	"30"	"70 years"	"70"	14289
+	"Montana"	"30"	"71 years"	"71"	13812
+	"Montana"	"30"	"72 years"	"72"	12831
+	"Montana"	"30"	"73 years"	"73"	11971
+	"Montana"	"30"	"74 years"	"74"	11455
+	"Montana"	"30"	"75 years"	"75"	10770
+	"Montana"	"30"	"76 years"	"76"	11185
+	"Montana"	"30"	"77 years"	"77"	7631
+	"Montana"	"30"	"78 years"	"78"	7208
+	"Montana"	"30"	"79 years"	"79"	6912
+	"Montana"	"30"	"80 years"	"80"	6800
+	"Montana"	"30"	"81 years"	"81"	5695
+	"Montana"	"30"	"82 years"	"82"	5039
+	"Montana"	"30"	"83 years"	"83"	4412
+	"Montana"	"30"	"84 years"	"84"	3972
+	"Montana"	"30"	"85+ years"	"85+"	21745
+"Total"	"Montana"	"30"			1132812
+	"Nebraska"	"31"	"< 1 year"	"0"	24144
+	"Nebraska"	"31"	"1 year"	"1"	24372
+	"Nebraska"	"31"	"2 years"	"2"	24488
+	"Nebraska"	"31"	"3 years"	"3"	25212
+	"Nebraska"	"31"	"4 years"	"4"	25443
+	"Nebraska"	"31"	"5 years"	"5"	26025
+	"Nebraska"	"31"	"6 years"	"6"	26701
+	"Nebraska"	"31"	"7 years"	"7"	27326
+	"Nebraska"	"31"	"8 years"	"8"	27421
+	"Nebraska"	"31"	"9 years"	"9"	27371
+	"Nebraska"	"31"	"10 years"	"10"	26997
+	"Nebraska"	"31"	"11 years"	"11"	26846
+	"Nebraska"	"31"	"12 years"	"12"	26834
+	"Nebraska"	"31"	"13 years"	"13"	27631
+	"Nebraska"	"31"	"14 years"	"14"	28317
+	"Nebraska"	"31"	"15 years"	"15"	28995
+	"Nebraska"	"31"	"16 years"	"16"	28762
+	"Nebraska"	"31"	"17 years"	"17"	28113
+	"Nebraska"	"31"	"18 years"	"18"	26930
+	"Nebraska"	"31"	"19 years"	"19"	28356
+	"Nebraska"	"31"	"20 years"	"20"	29060
+	"Nebraska"	"31"	"21 years"	"21"	28617
+	"Nebraska"	"31"	"22 years"	"22"	28075
+	"Nebraska"	"31"	"23 years"	"23"	27494
+	"Nebraska"	"31"	"24 years"	"24"	26316
+	"Nebraska"	"31"	"25 years"	"25"	25338
+	"Nebraska"	"31"	"26 years"	"26"	25061
+	"Nebraska"	"31"	"27 years"	"27"	24755
+	"Nebraska"	"31"	"28 years"	"28"	25068
+	"Nebraska"	"31"	"29 years"	"29"	25467
+	"Nebraska"	"31"	"30 years"	"30"	25467
+	"Nebraska"	"31"	"31 years"	"31"	25933
+	"Nebraska"	"31"	"32 years"	"32"	25592
+	"Nebraska"	"31"	"33 years"	"33"	25174
+	"Nebraska"	"31"	"34 years"	"34"	24723
+	"Nebraska"	"31"	"35 years"	"35"	25106
+	"Nebraska"	"31"	"36 years"	"36"	25664
+	"Nebraska"	"31"	"37 years"	"37"	25996
+	"Nebraska"	"31"	"38 years"	"38"	26614
+	"Nebraska"	"31"	"39 years"	"39"	26268
+	"Nebraska"	"31"	"40 years"	"40"	26767
+	"Nebraska"	"31"	"41 years"	"41"	26806
+	"Nebraska"	"31"	"42 years"	"42"	26204
+	"Nebraska"	"31"	"43 years"	"43"	25947
+	"Nebraska"	"31"	"44 years"	"44"	24263
+	"Nebraska"	"31"	"45 years"	"45"	23476
+	"Nebraska"	"31"	"46 years"	"46"	22806
+	"Nebraska"	"31"	"47 years"	"47"	21798
+	"Nebraska"	"31"	"48 years"	"48"	21993
+	"Nebraska"	"31"	"49 years"	"49"	20977
+	"Nebraska"	"31"	"50 years"	"50"	20906
+	"Nebraska"	"31"	"51 years"	"51"	21958
+	"Nebraska"	"31"	"52 years"	"52"	22901
+	"Nebraska"	"31"	"53 years"	"53"	22269
+	"Nebraska"	"31"	"54 years"	"54"	21518
+	"Nebraska"	"31"	"55 years"	"55"	20747
+	"Nebraska"	"31"	"56 years"	"56"	20914
+	"Nebraska"	"31"	"57 years"	"57"	21301
+	"Nebraska"	"31"	"58 years"	"58"	22483
+	"Nebraska"	"31"	"59 years"	"59"	23606
+	"Nebraska"	"31"	"60 years"	"60"	24042
+	"Nebraska"	"31"	"61 years"	"61"	24551
+	"Nebraska"	"31"	"62 years"	"62"	24608
+	"Nebraska"	"31"	"63 years"	"63"	24186
+	"Nebraska"	"31"	"64 years"	"64"	23734
+	"Nebraska"	"31"	"65 years"	"65"	23416
+	"Nebraska"	"31"	"66 years"	"66"	22867
+	"Nebraska"	"31"	"67 years"	"67"	21957
+	"Nebraska"	"31"	"68 years"	"68"	21499
+	"Nebraska"	"31"	"69 years"	"69"	20685
+	"Nebraska"	"31"	"70 years"	"70"	19826
+	"Nebraska"	"31"	"71 years"	"71"	19173
+	"Nebraska"	"31"	"72 years"	"72"	18138
+	"Nebraska"	"31"	"73 years"	"73"	16968
+	"Nebraska"	"31"	"74 years"	"74"	16240
+	"Nebraska"	"31"	"75 years"	"75"	15347
+	"Nebraska"	"31"	"76 years"	"76"	15901
+	"Nebraska"	"31"	"77 years"	"77"	10702
+	"Nebraska"	"31"	"78 years"	"78"	10342
+	"Nebraska"	"31"	"79 years"	"79"	10092
+	"Nebraska"	"31"	"80 years"	"80"	9921
+	"Nebraska"	"31"	"81 years"	"81"	8360
+	"Nebraska"	"31"	"82 years"	"82"	7311
+	"Nebraska"	"31"	"83 years"	"83"	6727
+	"Nebraska"	"31"	"84 years"	"84"	6312
+	"Nebraska"	"31"	"85+ years"	"85+"	37762
+"Total"	"Nebraska"	"31"			1978379
+	"Nevada"	"32"	"< 1 year"	"0"	32716
+	"Nevada"	"32"	"1 year"	"1"	33592
+	"Nevada"	"32"	"2 years"	"2"	33917
+	"Nevada"	"32"	"3 years"	"3"	35192
+	"Nevada"	"32"	"4 years"	"4"	36023
+	"Nevada"	"32"	"5 years"	"5"	36420
+	"Nevada"	"32"	"6 years"	"6"	37390
+	"Nevada"	"32"	"7 years"	"7"	38825
+	"Nevada"	"32"	"8 years"	"8"	38974
+	"Nevada"	"32"	"9 years"	"9"	38686
+	"Nevada"	"32"	"10 years"	"10"	38625
+	"Nevada"	"32"	"11 years"	"11"	38752
+	"Nevada"	"32"	"12 years"	"12"	39715
+	"Nevada"	"32"	"13 years"	"13"	39993
+	"Nevada"	"32"	"14 years"	"14"	40872
+	"Nevada"	"32"	"15 years"	"15"	42744
+	"Nevada"	"32"	"16 years"	"16"	42362
+	"Nevada"	"32"	"17 years"	"17"	41158
+	"Nevada"	"32"	"18 years"	"18"	36602
+	"Nevada"	"32"	"19 years"	"19"	32891
+	"Nevada"	"32"	"20 years"	"20"	33729
+	"Nevada"	"32"	"21 years"	"21"	34991
+	"Nevada"	"32"	"22 years"	"22"	37262
+	"Nevada"	"32"	"23 years"	"23"	39009
+	"Nevada"	"32"	"24 years"	"24"	39900
+	"Nevada"	"32"	"25 years"	"25"	41222
+	"Nevada"	"32"	"26 years"	"26"	42243
+	"Nevada"	"32"	"27 years"	"27"	43305
+	"Nevada"	"32"	"28 years"	"28"	44547
+	"Nevada"	"32"	"29 years"	"29"	45536
+	"Nevada"	"32"	"30 years"	"30"	46465
+	"Nevada"	"32"	"31 years"	"31"	48331
+	"Nevada"	"32"	"32 years"	"32"	49127
+	"Nevada"	"32"	"33 years"	"33"	49621
+	"Nevada"	"32"	"34 years"	"34"	47731
+	"Nevada"	"32"	"35 years"	"35"	46569
+	"Nevada"	"32"	"36 years"	"36"	45966
+	"Nevada"	"32"	"37 years"	"37"	45517
+	"Nevada"	"32"	"38 years"	"38"	45584
+	"Nevada"	"32"	"39 years"	"39"	44658
+	"Nevada"	"32"	"40 years"	"40"	44957
+	"Nevada"	"32"	"41 years"	"41"	44619
+	"Nevada"	"32"	"42 years"	"42"	43689
+	"Nevada"	"32"	"43 years"	"43"	43380
+	"Nevada"	"32"	"44 years"	"44"	41185
+	"Nevada"	"32"	"45 years"	"45"	40163
+	"Nevada"	"32"	"46 years"	"46"	39540
+	"Nevada"	"32"	"47 years"	"47"	38206
+	"Nevada"	"32"	"48 years"	"48"	38641
+	"Nevada"	"32"	"49 years"	"49"	38151
+	"Nevada"	"32"	"50 years"	"50"	38602
+	"Nevada"	"32"	"51 years"	"51"	40362
+	"Nevada"	"32"	"52 years"	"52"	42756
+	"Nevada"	"32"	"53 years"	"53"	42135
+	"Nevada"	"32"	"54 years"	"54"	40412
+	"Nevada"	"32"	"55 years"	"55"	39005
+	"Nevada"	"32"	"56 years"	"56"	38736
+	"Nevada"	"32"	"57 years"	"57"	39060
+	"Nevada"	"32"	"58 years"	"58"	40178
+	"Nevada"	"32"	"59 years"	"59"	40511
+	"Nevada"	"32"	"60 years"	"60"	40282
+	"Nevada"	"32"	"61 years"	"61"	40325
+	"Nevada"	"32"	"62 years"	"62"	39820
+	"Nevada"	"32"	"63 years"	"63"	39185
+	"Nevada"	"32"	"64 years"	"64"	37805
+	"Nevada"	"32"	"65 years"	"65"	37830
+	"Nevada"	"32"	"66 years"	"66"	37306
+	"Nevada"	"32"	"67 years"	"67"	36132
+	"Nevada"	"32"	"68 years"	"68"	35440
+	"Nevada"	"32"	"69 years"	"69"	33954
+	"Nevada"	"32"	"70 years"	"70"	32547
+	"Nevada"	"32"	"71 years"	"71"	31146
+	"Nevada"	"32"	"72 years"	"72"	29791
+	"Nevada"	"32"	"73 years"	"73"	28751
+	"Nevada"	"32"	"74 years"	"74"	27931
+	"Nevada"	"32"	"75 years"	"75"	27370
+	"Nevada"	"32"	"76 years"	"76"	28599
+	"Nevada"	"32"	"77 years"	"77"	20189
+	"Nevada"	"32"	"78 years"	"78"	18875
+	"Nevada"	"32"	"79 years"	"79"	18103
+	"Nevada"	"32"	"80 years"	"80"	17563
+	"Nevada"	"32"	"81 years"	"81"	14439
+	"Nevada"	"32"	"82 years"	"82"	12413
+	"Nevada"	"32"	"83 years"	"83"	10909
+	"Nevada"	"32"	"84 years"	"84"	9641
+	"Nevada"	"32"	"85+ years"	"85+"	46780
+"Total"	"Nevada"	"32"			3194176
+	"New Hampshire"	"33"	"< 1 year"	"0"	12164
+	"New Hampshire"	"33"	"1 year"	"1"	12523
+	"New Hampshire"	"33"	"2 years"	"2"	12274
+	"New Hampshire"	"33"	"3 years"	"3"	12727
+	"New Hampshire"	"33"	"4 years"	"4"	12897
+	"New Hampshire"	"33"	"5 years"	"5"	13010
+	"New Hampshire"	"33"	"6 years"	"6"	13306
+	"New Hampshire"	"33"	"7 years"	"7"	13664
+	"New Hampshire"	"33"	"8 years"	"8"	13869
+	"New Hampshire"	"33"	"9 years"	"9"	13935
+	"New Hampshire"	"33"	"10 years"	"10"	14174
+	"New Hampshire"	"33"	"11 years"	"11"	14195
+	"New Hampshire"	"33"	"12 years"	"12"	14646
+	"New Hampshire"	"33"	"13 years"	"13"	14923
+	"New Hampshire"	"33"	"14 years"	"14"	15267
+	"New Hampshire"	"33"	"15 years"	"15"	16060
+	"New Hampshire"	"33"	"16 years"	"16"	16184
+	"New Hampshire"	"33"	"17 years"	"17"	16232
+	"New Hampshire"	"33"	"18 years"	"18"	16866
+	"New Hampshire"	"33"	"19 years"	"19"	17799
+	"New Hampshire"	"33"	"20 years"	"20"	18148
+	"New Hampshire"	"33"	"21 years"	"21"	18057
+	"New Hampshire"	"33"	"22 years"	"22"	17155
+	"New Hampshire"	"33"	"23 years"	"23"	15852
+	"New Hampshire"	"33"	"24 years"	"24"	15957
+	"New Hampshire"	"33"	"25 years"	"25"	15952
+	"New Hampshire"	"33"	"26 years"	"26"	16587
+	"New Hampshire"	"33"	"27 years"	"27"	16946
+	"New Hampshire"	"33"	"28 years"	"28"	17494
+	"New Hampshire"	"33"	"29 years"	"29"	18192
+	"New Hampshire"	"33"	"30 years"	"30"	18355
+	"New Hampshire"	"33"	"31 years"	"31"	18523
+	"New Hampshire"	"33"	"32 years"	"32"	18959
+	"New Hampshire"	"33"	"33 years"	"33"	18935
+	"New Hampshire"	"33"	"34 years"	"34"	18600
+	"New Hampshire"	"33"	"35 years"	"35"	18555
+	"New Hampshire"	"33"	"36 years"	"36"	18440
+	"New Hampshire"	"33"	"37 years"	"37"	18553
+	"New Hampshire"	"33"	"38 years"	"38"	18099
+	"New Hampshire"	"33"	"39 years"	"39"	17421
+	"New Hampshire"	"33"	"40 years"	"40"	17631
+	"New Hampshire"	"33"	"41 years"	"41"	17539
+	"New Hampshire"	"33"	"42 years"	"42"	17185
+	"New Hampshire"	"33"	"43 years"	"43"	16919
+	"New Hampshire"	"33"	"44 years"	"44"	16294
+	"New Hampshire"	"33"	"45 years"	"45"	15749
+	"New Hampshire"	"33"	"46 years"	"46"	15533
+	"New Hampshire"	"33"	"47 years"	"47"	15023
+	"New Hampshire"	"33"	"48 years"	"48"	15637
+	"New Hampshire"	"33"	"49 years"	"49"	15649
+	"New Hampshire"	"33"	"50 years"	"50"	16357
+	"New Hampshire"	"33"	"51 years"	"51"	17834
+	"New Hampshire"	"33"	"52 years"	"52"	19420
+	"New Hampshire"	"33"	"53 years"	"53"	19347
+	"New Hampshire"	"33"	"54 years"	"54"	19040
+	"New Hampshire"	"33"	"55 years"	"55"	18979
+	"New Hampshire"	"33"	"56 years"	"56"	19594
+	"New Hampshire"	"33"	"57 years"	"57"	20115
+	"New Hampshire"	"33"	"58 years"	"58"	21179
+	"New Hampshire"	"33"	"59 years"	"59"	22125
+	"New Hampshire"	"33"	"60 years"	"60"	22479
+	"New Hampshire"	"33"	"61 years"	"61"	22615
+	"New Hampshire"	"33"	"62 years"	"62"	22741
+	"New Hampshire"	"33"	"63 years"	"63"	22084
+	"New Hampshire"	"33"	"64 years"	"64"	21965
+	"New Hampshire"	"33"	"65 years"	"65"	21537
+	"New Hampshire"	"33"	"66 years"	"66"	20969
+	"New Hampshire"	"33"	"67 years"	"67"	19451
+	"New Hampshire"	"33"	"68 years"	"68"	18714
+	"New Hampshire"	"33"	"69 years"	"69"	17944
+	"New Hampshire"	"33"	"70 years"	"70"	17077
+	"New Hampshire"	"33"	"71 years"	"71"	16247
+	"New Hampshire"	"33"	"72 years"	"72"	15238
+	"New Hampshire"	"33"	"73 years"	"73"	14280
+	"New Hampshire"	"33"	"74 years"	"74"	13993
+	"New Hampshire"	"33"	"75 years"	"75"	13700
+	"New Hampshire"	"33"	"76 years"	"76"	14406
+	"New Hampshire"	"33"	"77 years"	"77"	9495
+	"New Hampshire"	"33"	"78 years"	"78"	8890
+	"New Hampshire"	"33"	"79 years"	"79"	8575
+	"New Hampshire"	"33"	"80 years"	"80"	8624
+	"New Hampshire"	"33"	"81 years"	"81"	7208
+	"New Hampshire"	"33"	"82 years"	"82"	6115
+	"New Hampshire"	"33"	"83 years"	"83"	5300
+	"New Hampshire"	"33"	"84 years"	"84"	4904
+	"New Hampshire"	"33"	"85+ years"	"85+"	28859
+"Total"	"New Hampshire"	"33"			1402054
+	"New Jersey"	"34"	"< 1 year"	"0"	102477
+	"New Jersey"	"34"	"1 year"	"1"	104348
+	"New Jersey"	"34"	"2 years"	"2"	100230
+	"New Jersey"	"34"	"3 years"	"3"	105135
+	"New Jersey"	"34"	"4 years"	"4"	106880
+	"New Jersey"	"34"	"5 years"	"5"	108990
+	"New Jersey"	"34"	"6 years"	"6"	109711
+	"New Jersey"	"34"	"7 years"	"7"	111351
+	"New Jersey"	"34"	"8 years"	"8"	111606
+	"New Jersey"	"34"	"9 years"	"9"	111370
+	"New Jersey"	"34"	"10 years"	"10"	111623
+	"New Jersey"	"34"	"11 years"	"11"	112472
+	"New Jersey"	"34"	"12 years"	"12"	114228
+	"New Jersey"	"34"	"13 years"	"13"	116129
+	"New Jersey"	"34"	"14 years"	"14"	117793
+	"New Jersey"	"34"	"15 years"	"15"	122262
+	"New Jersey"	"34"	"16 years"	"16"	122569
+	"New Jersey"	"34"	"17 years"	"17"	121116
+	"New Jersey"	"34"	"18 years"	"18"	113750
+	"New Jersey"	"34"	"19 years"	"19"	106146
+	"New Jersey"	"34"	"20 years"	"20"	108426
+	"New Jersey"	"34"	"21 years"	"21"	109643
+	"New Jersey"	"34"	"22 years"	"22"	111996
+	"New Jersey"	"34"	"23 years"	"23"	111660
+	"New Jersey"	"34"	"24 years"	"24"	110636
+	"New Jersey"	"34"	"25 years"	"25"	110763
+	"New Jersey"	"34"	"26 years"	"26"	112326
+	"New Jersey"	"34"	"27 years"	"27"	114215
+	"New Jersey"	"34"	"28 years"	"28"	116098
+	"New Jersey"	"34"	"29 years"	"29"	118308
+	"New Jersey"	"34"	"30 years"	"30"	121053
+	"New Jersey"	"34"	"31 years"	"31"	122706
+	"New Jersey"	"34"	"32 years"	"32"	124403
+	"New Jersey"	"34"	"33 years"	"33"	126195
+	"New Jersey"	"34"	"34 years"	"34"	124403
+	"New Jersey"	"34"	"35 years"	"35"	123382
+	"New Jersey"	"34"	"36 years"	"36"	123610
+	"New Jersey"	"34"	"37 years"	"37"	124518
+	"New Jersey"	"34"	"38 years"	"38"	124957
+	"New Jersey"	"34"	"39 years"	"39"	122630
+	"New Jersey"	"34"	"40 years"	"40"	124062
+	"New Jersey"	"34"	"41 years"	"41"	124385
+	"New Jersey"	"34"	"42 years"	"42"	123008
+	"New Jersey"	"34"	"43 years"	"43"	123523
+	"New Jersey"	"34"	"44 years"	"44"	119577
+	"New Jersey"	"34"	"45 years"	"45"	117843
+	"New Jersey"	"34"	"46 years"	"46"	116888
+	"New Jersey"	"34"	"47 years"	"47"	113755
+	"New Jersey"	"34"	"48 years"	"48"	115270
+	"New Jersey"	"34"	"49 years"	"49"	113009
+	"New Jersey"	"34"	"50 years"	"50"	114354
+	"New Jersey"	"34"	"51 years"	"51"	119630
+	"New Jersey"	"34"	"52 years"	"52"	126974
+	"New Jersey"	"34"	"53 years"	"53"	126518
+	"New Jersey"	"34"	"54 years"	"54"	122867
+	"New Jersey"	"34"	"55 years"	"55"	121914
+	"New Jersey"	"34"	"56 years"	"56"	122719
+	"New Jersey"	"34"	"57 years"	"57"	124934
+	"New Jersey"	"34"	"58 years"	"58"	127824
+	"New Jersey"	"34"	"59 years"	"59"	129118
+	"New Jersey"	"34"	"60 years"	"60"	128416
+	"New Jersey"	"34"	"61 years"	"61"	126860
+	"New Jersey"	"34"	"62 years"	"62"	125452
+	"New Jersey"	"34"	"63 years"	"63"	122546
+	"New Jersey"	"34"	"64 years"	"64"	118937
+	"New Jersey"	"34"	"65 years"	"65"	116705
+	"New Jersey"	"34"	"66 years"	"66"	112902
+	"New Jersey"	"34"	"67 years"	"67"	105945
+	"New Jersey"	"34"	"68 years"	"68"	101986
+	"New Jersey"	"34"	"69 years"	"69"	96657
+	"New Jersey"	"34"	"70 years"	"70"	91472
+	"New Jersey"	"34"	"71 years"	"71"	86990
+	"New Jersey"	"34"	"72 years"	"72"	82776
+	"New Jersey"	"34"	"73 years"	"73"	78428
+	"New Jersey"	"34"	"74 years"	"74"	75678
+	"New Jersey"	"34"	"75 years"	"75"	74434
+	"New Jersey"	"34"	"76 years"	"76"	78657
+	"New Jersey"	"34"	"77 years"	"77"	56746
+	"New Jersey"	"34"	"78 years"	"78"	52900
+	"New Jersey"	"34"	"79 years"	"79"	50744
+	"New Jersey"	"34"	"80 years"	"80"	51742
+	"New Jersey"	"34"	"81 years"	"81"	43843
+	"New Jersey"	"34"	"82 years"	"82"	37986
+	"New Jersey"	"34"	"83 years"	"83"	33984
+	"New Jersey"	"34"	"84 years"	"84"	31064
+	"New Jersey"	"34"	"85+ years"	"85+"	186705
+"Total"	"New Jersey"	"34"			9290841
+	"New Mexico"	"35"	"< 1 year"	"0"	20589
+	"New Mexico"	"35"	"1 year"	"1"	20921
+	"New Mexico"	"35"	"2 years"	"2"	21293
+	"New Mexico"	"35"	"3 years"	"3"	21816
+	"New Mexico"	"35"	"4 years"	"4"	22702
+	"New Mexico"	"35"	"5 years"	"5"	23270
+	"New Mexico"	"35"	"6 years"	"6"	23851
+	"New Mexico"	"35"	"7 years"	"7"	24923
+	"New Mexico"	"35"	"8 years"	"8"	25389
+	"New Mexico"	"35"	"9 years"	"9"	25579
+	"New Mexico"	"35"	"10 years"	"10"	25951
+	"New Mexico"	"35"	"11 years"	"11"	26029
+	"New Mexico"	"35"	"12 years"	"12"	26407
+	"New Mexico"	"35"	"13 years"	"13"	27339
+	"New Mexico"	"35"	"14 years"	"14"	28088
+	"New Mexico"	"35"	"15 years"	"15"	29156
+	"New Mexico"	"35"	"16 years"	"16"	29279
+	"New Mexico"	"35"	"17 years"	"17"	28765
+	"New Mexico"	"35"	"18 years"	"18"	28367
+	"New Mexico"	"35"	"19 years"	"19"	28896
+	"New Mexico"	"35"	"20 years"	"20"	29289
+	"New Mexico"	"35"	"21 years"	"21"	28901
+	"New Mexico"	"35"	"22 years"	"22"	28685
+	"New Mexico"	"35"	"23 years"	"23"	28608
+	"New Mexico"	"35"	"24 years"	"24"	27649
+	"New Mexico"	"35"	"25 years"	"25"	27017
+	"New Mexico"	"35"	"26 years"	"26"	26363
+	"New Mexico"	"35"	"27 years"	"27"	26430
+	"New Mexico"	"35"	"28 years"	"28"	27144
+	"New Mexico"	"35"	"29 years"	"29"	27451
+	"New Mexico"	"35"	"30 years"	"30"	28215
+	"New Mexico"	"35"	"31 years"	"31"	29005
+	"New Mexico"	"35"	"32 years"	"32"	28748
+	"New Mexico"	"35"	"33 years"	"33"	28851
+	"New Mexico"	"35"	"34 years"	"34"	27752
+	"New Mexico"	"35"	"35 years"	"35"	27663
+	"New Mexico"	"35"	"36 years"	"36"	27963
+	"New Mexico"	"35"	"37 years"	"37"	27822
+	"New Mexico"	"35"	"38 years"	"38"	28192
+	"New Mexico"	"35"	"39 years"	"39"	27732
+	"New Mexico"	"35"	"40 years"	"40"	27820
+	"New Mexico"	"35"	"41 years"	"41"	27463
+	"New Mexico"	"35"	"42 years"	"42"	26809
+	"New Mexico"	"35"	"43 years"	"43"	26554
+	"New Mexico"	"35"	"44 years"	"44"	25111
+	"New Mexico"	"35"	"45 years"	"45"	24464
+	"New Mexico"	"35"	"46 years"	"46"	23950
+	"New Mexico"	"35"	"47 years"	"47"	23146
+	"New Mexico"	"35"	"48 years"	"48"	23044
+	"New Mexico"	"35"	"49 years"	"49"	22452
+	"New Mexico"	"35"	"50 years"	"50"	22700
+	"New Mexico"	"35"	"51 years"	"51"	23575
+	"New Mexico"	"35"	"52 years"	"52"	24539
+	"New Mexico"	"35"	"53 years"	"53"	24179
+	"New Mexico"	"35"	"54 years"	"54"	23535
+	"New Mexico"	"35"	"55 years"	"55"	23044
+	"New Mexico"	"35"	"56 years"	"56"	23178
+	"New Mexico"	"35"	"57 years"	"57"	23660
+	"New Mexico"	"35"	"58 years"	"58"	25121
+	"New Mexico"	"35"	"59 years"	"59"	26066
+	"New Mexico"	"35"	"60 years"	"60"	26801
+	"New Mexico"	"35"	"61 years"	"61"	27936
+	"New Mexico"	"35"	"62 years"	"62"	27982
+	"New Mexico"	"35"	"63 years"	"63"	27712
+	"New Mexico"	"35"	"64 years"	"64"	26889
+	"New Mexico"	"35"	"65 years"	"65"	26983
+	"New Mexico"	"35"	"66 years"	"66"	27062
+	"New Mexico"	"35"	"67 years"	"67"	26187
+	"New Mexico"	"35"	"68 years"	"68"	25722
+	"New Mexico"	"35"	"69 years"	"69"	25214
+	"New Mexico"	"35"	"70 years"	"70"	24556
+	"New Mexico"	"35"	"71 years"	"71"	23799
+	"New Mexico"	"35"	"72 years"	"72"	22746
+	"New Mexico"	"35"	"73 years"	"73"	21956
+	"New Mexico"	"35"	"74 years"	"74"	21289
+	"New Mexico"	"35"	"75 years"	"75"	20503
+	"New Mexico"	"35"	"76 years"	"76"	20942
+	"New Mexico"	"35"	"77 years"	"77"	14960
+	"New Mexico"	"35"	"78 years"	"78"	14161
+	"New Mexico"	"35"	"79 years"	"79"	13216
+	"New Mexico"	"35"	"80 years"	"80"	12787
+	"New Mexico"	"35"	"81 years"	"81"	10750
+	"New Mexico"	"35"	"82 years"	"82"	9496
+	"New Mexico"	"35"	"83 years"	"83"	8440
+	"New Mexico"	"35"	"84 years"	"84"	7642
+	"New Mexico"	"35"	"85+ years"	"85+"	40140
+"Total"	"New Mexico"	"35"			2114371
+	"New York"	"36"	"< 1 year"	"0"	209673
+	"New York"	"36"	"1 year"	"1"	208015
+	"New York"	"36"	"2 years"	"2"	198250
+	"New York"	"36"	"3 years"	"3"	209648
+	"New York"	"36"	"4 years"	"4"	213230
+	"New York"	"36"	"5 years"	"5"	216890
+	"New York"	"36"	"6 years"	"6"	218390
+	"New York"	"36"	"7 years"	"7"	221231
+	"New York"	"36"	"8 years"	"8"	222573
+	"New York"	"36"	"9 years"	"9"	220916
+	"New York"	"36"	"10 years"	"10"	221549
+	"New York"	"36"	"11 years"	"11"	222249
+	"New York"	"36"	"12 years"	"12"	224944
+	"New York"	"36"	"13 years"	"13"	225671
+	"New York"	"36"	"14 years"	"14"	226081
+	"New York"	"36"	"15 years"	"15"	233776
+	"New York"	"36"	"16 years"	"16"	233894
+	"New York"	"36"	"17 years"	"17"	232928
+	"New York"	"36"	"18 years"	"18"	248332
+	"New York"	"36"	"19 years"	"19"	249371
+	"New York"	"36"	"20 years"	"20"	250657
+	"New York"	"36"	"21 years"	"21"	246244
+	"New York"	"36"	"22 years"	"22"	243775
+	"New York"	"36"	"23 years"	"23"	249558
+	"New York"	"36"	"24 years"	"24"	253398
+	"New York"	"36"	"25 years"	"25"	258171
+	"New York"	"36"	"26 years"	"26"	261362
+	"New York"	"36"	"27 years"	"27"	266469
+	"New York"	"36"	"28 years"	"28"	270588
+	"New York"	"36"	"29 years"	"29"	276260
+	"New York"	"36"	"30 years"	"30"	277669
+	"New York"	"36"	"31 years"	"31"	279633
+	"New York"	"36"	"32 years"	"32"	284018
+	"New York"	"36"	"33 years"	"33"	285312
+	"New York"	"36"	"34 years"	"34"	276812
+	"New York"	"36"	"35 years"	"35"	271700
+	"New York"	"36"	"36 years"	"36"	266543
+	"New York"	"36"	"37 years"	"37"	263481
+	"New York"	"36"	"38 years"	"38"	260096
+	"New York"	"36"	"39 years"	"39"	251396
+	"New York"	"36"	"40 years"	"40"	252994
+	"New York"	"36"	"41 years"	"41"	250067
+	"New York"	"36"	"42 years"	"42"	245378
+	"New York"	"36"	"43 years"	"43"	246066
+	"New York"	"36"	"44 years"	"44"	237893
+	"New York"	"36"	"45 years"	"45"	232274
+	"New York"	"36"	"46 years"	"46"	230111
+	"New York"	"36"	"47 years"	"47"	224087
+	"New York"	"36"	"48 years"	"48"	228419
+	"New York"	"36"	"49 years"	"49"	222879
+	"New York"	"36"	"50 years"	"50"	225088
+	"New York"	"36"	"51 years"	"51"	237180
+	"New York"	"36"	"52 years"	"52"	254889
+	"New York"	"36"	"53 years"	"53"	256875
+	"New York"	"36"	"54 years"	"54"	250371
+	"New York"	"36"	"55 years"	"55"	247683
+	"New York"	"36"	"56 years"	"56"	249993
+	"New York"	"36"	"57 years"	"57"	255620
+	"New York"	"36"	"58 years"	"58"	265453
+	"New York"	"36"	"59 years"	"59"	269245
+	"New York"	"36"	"60 years"	"60"	266286
+	"New York"	"36"	"61 years"	"61"	263739
+	"New York"	"36"	"62 years"	"62"	262819
+	"New York"	"36"	"63 years"	"63"	259067
+	"New York"	"36"	"64 years"	"64"	251886
+	"New York"	"36"	"65 years"	"65"	247191
+	"New York"	"36"	"66 years"	"66"	240318
+	"New York"	"36"	"67 years"	"67"	229164
+	"New York"	"36"	"68 years"	"68"	223012
+	"New York"	"36"	"69 years"	"69"	211717
+	"New York"	"36"	"70 years"	"70"	200986
+	"New York"	"36"	"71 years"	"71"	193283
+	"New York"	"36"	"72 years"	"72"	184895
+	"New York"	"36"	"73 years"	"73"	177259
+	"New York"	"36"	"74 years"	"74"	170269
+	"New York"	"36"	"75 years"	"75"	164675
+	"New York"	"36"	"76 years"	"76"	170324
+	"New York"	"36"	"77 years"	"77"	122958
+	"New York"	"36"	"78 years"	"78"	116772
+	"New York"	"36"	"79 years"	"79"	111115
+	"New York"	"36"	"80 years"	"80"	110939
+	"New York"	"36"	"81 years"	"81"	95309
+	"New York"	"36"	"82 years"	"82"	84434
+	"New York"	"36"	"83 years"	"83"	76736
+	"New York"	"36"	"84 years"	"84"	70098
+	"New York"	"36"	"85+ years"	"85+"	432647
+"Total"	"New York"	"36"			19571216
+	"North Carolina"	"37"	"< 1 year"	"0"	120602
+	"North Carolina"	"37"	"1 year"	"1"	123076
+	"North Carolina"	"37"	"2 years"	"2"	119646
+	"North Carolina"	"37"	"3 years"	"3"	121061
+	"North Carolina"	"37"	"4 years"	"4"	122070
+	"North Carolina"	"37"	"5 years"	"5"	124879
+	"North Carolina"	"37"	"6 years"	"6"	126360
+	"North Carolina"	"37"	"7 years"	"7"	128766
+	"North Carolina"	"37"	"8 years"	"8"	129902
+	"North Carolina"	"37"	"9 years"	"9"	129093
+	"North Carolina"	"37"	"10 years"	"10"	128618
+	"North Carolina"	"37"	"11 years"	"11"	129359
+	"North Carolina"	"37"	"12 years"	"12"	130525
+	"North Carolina"	"37"	"13 years"	"13"	135099
+	"North Carolina"	"37"	"14 years"	"14"	138949
+	"North Carolina"	"37"	"15 years"	"15"	144163
+	"North Carolina"	"37"	"16 years"	"16"	143493
+	"North Carolina"	"37"	"17 years"	"17"	140962
+	"North Carolina"	"37"	"18 years"	"18"	144801
+	"North Carolina"	"37"	"19 years"	"19"	150255
+	"North Carolina"	"37"	"20 years"	"20"	148118
+	"North Carolina"	"37"	"21 years"	"21"	145481
+	"North Carolina"	"37"	"22 years"	"22"	146871
+	"North Carolina"	"37"	"23 years"	"23"	145024
+	"North Carolina"	"37"	"24 years"	"24"	141639
+	"North Carolina"	"37"	"25 years"	"25"	140072
+	"North Carolina"	"37"	"26 years"	"26"	138498
+	"North Carolina"	"37"	"27 years"	"27"	139449
+	"North Carolina"	"37"	"28 years"	"28"	142088
+	"North Carolina"	"37"	"29 years"	"29"	145770
+	"North Carolina"	"37"	"30 years"	"30"	147804
+	"North Carolina"	"37"	"31 years"	"31"	150758
+	"North Carolina"	"37"	"32 years"	"32"	152709
+	"North Carolina"	"37"	"33 years"	"33"	152691
+	"North Carolina"	"37"	"34 years"	"34"	147882
+	"North Carolina"	"37"	"35 years"	"35"	143795
+	"North Carolina"	"37"	"36 years"	"36"	140935
+	"North Carolina"	"37"	"37 years"	"37"	140410
+	"North Carolina"	"37"	"38 years"	"38"	139290
+	"North Carolina"	"37"	"39 years"	"39"	135315
+	"North Carolina"	"37"	"40 years"	"40"	138210
+	"North Carolina"	"37"	"41 years"	"41"	138246
+	"North Carolina"	"37"	"42 years"	"42"	136793
+	"North Carolina"	"37"	"43 years"	"43"	137661
+	"North Carolina"	"37"	"44 years"	"44"	133473
+	"North Carolina"	"37"	"45 years"	"45"	132417
+	"North Carolina"	"37"	"46 years"	"46"	131822
+	"North Carolina"	"37"	"47 years"	"47"	127391
+	"North Carolina"	"37"	"48 years"	"48"	129992
+	"North Carolina"	"37"	"49 years"	"49"	128652
+	"North Carolina"	"37"	"50 years"	"50"	132069
+	"North Carolina"	"37"	"51 years"	"51"	139827
+	"North Carolina"	"37"	"52 years"	"52"	148506
+	"North Carolina"	"37"	"53 years"	"53"	144688
+	"North Carolina"	"37"	"54 years"	"54"	137882
+	"North Carolina"	"37"	"55 years"	"55"	134353
+	"North Carolina"	"37"	"56 years"	"56"	134213
+	"North Carolina"	"37"	"57 years"	"57"	134611
+	"North Carolina"	"37"	"58 years"	"58"	138499
+	"North Carolina"	"37"	"59 years"	"59"	142165
+	"North Carolina"	"37"	"60 years"	"60"	140704
+	"North Carolina"	"37"	"61 years"	"61"	140340
+	"North Carolina"	"37"	"62 years"	"62"	139259
+	"North Carolina"	"37"	"63 years"	"63"	135523
+	"North Carolina"	"37"	"64 years"	"64"	133428
+	"North Carolina"	"37"	"65 years"	"65"	132120
+	"North Carolina"	"37"	"66 years"	"66"	129375
+	"North Carolina"	"37"	"67 years"	"67"	123546
+	"North Carolina"	"37"	"68 years"	"68"	120349
+	"North Carolina"	"37"	"69 years"	"69"	116819
+	"North Carolina"	"37"	"70 years"	"70"	111794
+	"North Carolina"	"37"	"71 years"	"71"	107665
+	"North Carolina"	"37"	"72 years"	"72"	101733
+	"North Carolina"	"37"	"73 years"	"73"	96309
+	"North Carolina"	"37"	"74 years"	"74"	93749
+	"North Carolina"	"37"	"75 years"	"75"	91746
+	"North Carolina"	"37"	"76 years"	"76"	96472
+	"North Carolina"	"37"	"77 years"	"77"	66563
+	"North Carolina"	"37"	"78 years"	"78"	62720
+	"North Carolina"	"37"	"79 years"	"79"	59701
+	"North Carolina"	"37"	"80 years"	"80"	58871
+	"North Carolina"	"37"	"81 years"	"81"	48582
+	"North Carolina"	"37"	"82 years"	"82"	42337
+	"North Carolina"	"37"	"83 years"	"83"	37392
+	"North Carolina"	"37"	"84 years"	"84"	33004
+	"North Carolina"	"37"	"85+ years"	"85+"	177642
+"Total"	"North Carolina"	"37"			10835491
+	"North Dakota"	"38"	"< 1 year"	"0"	9626
+	"North Dakota"	"38"	"1 year"	"1"	9763
+	"North Dakota"	"38"	"2 years"	"2"	9775
+	"North Dakota"	"38"	"3 years"	"3"	10085
+	"North Dakota"	"38"	"4 years"	"4"	10058
+	"North Dakota"	"38"	"5 years"	"5"	10297
+	"North Dakota"	"38"	"6 years"	"6"	10691
+	"North Dakota"	"38"	"7 years"	"7"	10899
+	"North Dakota"	"38"	"8 years"	"8"	10816
+	"North Dakota"	"38"	"9 years"	"9"	10675
+	"North Dakota"	"38"	"10 years"	"10"	10463
+	"North Dakota"	"38"	"11 years"	"11"	10367
+	"North Dakota"	"38"	"12 years"	"12"	10017
+	"North Dakota"	"38"	"13 years"	"13"	10111
+	"North Dakota"	"38"	"14 years"	"14"	10248
+	"North Dakota"	"38"	"15 years"	"15"	10447
+	"North Dakota"	"38"	"16 years"	"16"	10314
+	"North Dakota"	"38"	"17 years"	"17"	10082
+	"North Dakota"	"38"	"18 years"	"18"	10993
+	"North Dakota"	"38"	"19 years"	"19"	13907
+	"North Dakota"	"38"	"20 years"	"20"	12587
+	"North Dakota"	"38"	"21 years"	"21"	12492
+	"North Dakota"	"38"	"22 years"	"22"	13202
+	"North Dakota"	"38"	"23 years"	"23"	12634
+	"North Dakota"	"38"	"24 years"	"24"	11751
+	"North Dakota"	"38"	"25 years"	"25"	11261
+	"North Dakota"	"38"	"26 years"	"26"	10655
+	"North Dakota"	"38"	"27 years"	"27"	10406
+	"North Dakota"	"38"	"28 years"	"28"	10530
+	"North Dakota"	"38"	"29 years"	"29"	10764
+	"North Dakota"	"38"	"30 years"	"30"	10973
+	"North Dakota"	"38"	"31 years"	"31"	11278
+	"North Dakota"	"38"	"32 years"	"32"	11370
+	"North Dakota"	"38"	"33 years"	"33"	11357
+	"North Dakota"	"38"	"34 years"	"34"	10919
+	"North Dakota"	"38"	"35 years"	"35"	10678
+	"North Dakota"	"38"	"36 years"	"36"	10528
+	"North Dakota"	"38"	"37 years"	"37"	10648
+	"North Dakota"	"38"	"38 years"	"38"	10771
+	"North Dakota"	"38"	"39 years"	"39"	10447
+	"North Dakota"	"38"	"40 years"	"40"	10537
+	"North Dakota"	"38"	"41 years"	"41"	10317
+	"North Dakota"	"38"	"42 years"	"42"	10021
+	"North Dakota"	"38"	"43 years"	"43"	9609
+	"North Dakota"	"38"	"44 years"	"44"	9052
+	"North Dakota"	"38"	"45 years"	"45"	8659
+	"North Dakota"	"38"	"46 years"	"46"	8291
+	"North Dakota"	"38"	"47 years"	"47"	7782
+	"North Dakota"	"38"	"48 years"	"48"	7867
+	"North Dakota"	"38"	"49 years"	"49"	7531
+	"North Dakota"	"38"	"50 years"	"50"	7472
+	"North Dakota"	"38"	"51 years"	"51"	7714
+	"North Dakota"	"38"	"52 years"	"52"	7988
+	"North Dakota"	"38"	"53 years"	"53"	7961
+	"North Dakota"	"38"	"54 years"	"54"	7872
+	"North Dakota"	"38"	"55 years"	"55"	7701
+	"North Dakota"	"38"	"56 years"	"56"	7775
+	"North Dakota"	"38"	"57 years"	"57"	7950
+	"North Dakota"	"38"	"58 years"	"58"	8344
+	"North Dakota"	"38"	"59 years"	"59"	8826
+	"North Dakota"	"38"	"60 years"	"60"	9031
+	"North Dakota"	"38"	"61 years"	"61"	9354
+	"North Dakota"	"38"	"62 years"	"62"	9411
+	"North Dakota"	"38"	"63 years"	"63"	9356
+	"North Dakota"	"38"	"64 years"	"64"	9304
+	"North Dakota"	"38"	"65 years"	"65"	9298
+	"North Dakota"	"38"	"66 years"	"66"	9003
+	"North Dakota"	"38"	"67 years"	"67"	8641
+	"North Dakota"	"38"	"68 years"	"68"	8463
+	"North Dakota"	"38"	"69 years"	"69"	8091
+	"North Dakota"	"38"	"70 years"	"70"	7685
+	"North Dakota"	"38"	"71 years"	"71"	7396
+	"North Dakota"	"38"	"72 years"	"72"	6754
+	"North Dakota"	"38"	"73 years"	"73"	6296
+	"North Dakota"	"38"	"74 years"	"74"	5898
+	"North Dakota"	"38"	"75 years"	"75"	5621
+	"North Dakota"	"38"	"76 years"	"76"	5839
+	"North Dakota"	"38"	"77 years"	"77"	4045
+	"North Dakota"	"38"	"78 years"	"78"	3976
+	"North Dakota"	"38"	"79 years"	"79"	3794
+	"North Dakota"	"38"	"80 years"	"80"	3813
+	"North Dakota"	"38"	"81 years"	"81"	3216
+	"North Dakota"	"38"	"82 years"	"82"	2866
+	"North Dakota"	"38"	"83 years"	"83"	2633
+	"North Dakota"	"38"	"84 years"	"84"	2453
+	"North Dakota"	"38"	"85+ years"	"85+"	17535
+"Total"	"North Dakota"	"38"			783926
+	"Ohio"	"39"	"< 1 year"	"0"	128059
+	"Ohio"	"39"	"1 year"	"1"	129457
+	"Ohio"	"39"	"2 years"	"2"	129285
+	"Ohio"	"39"	"3 years"	"3"	134972
+	"Ohio"	"39"	"4 years"	"4"	136920
+	"Ohio"	"39"	"5 years"	"5"	140262
+	"Ohio"	"39"	"6 years"	"6"	141417
+	"Ohio"	"39"	"7 years"	"7"	144326
+	"Ohio"	"39"	"8 years"	"8"	145591
+	"Ohio"	"39"	"9 years"	"9"	145496
+	"Ohio"	"39"	"10 years"	"10"	145128
+	"Ohio"	"39"	"11 years"	"11"	144045
+	"Ohio"	"39"	"12 years"	"12"	144151
+	"Ohio"	"39"	"13 years"	"13"	147684
+	"Ohio"	"39"	"14 years"	"14"	151942
+	"Ohio"	"39"	"15 years"	"15"	156828
+	"Ohio"	"39"	"16 years"	"16"	157042
+	"Ohio"	"39"	"17 years"	"17"	155649
+	"Ohio"	"39"	"18 years"	"18"	148320
+	"Ohio"	"39"	"19 years"	"19"	150234
+	"Ohio"	"39"	"20 years"	"20"	146830
+	"Ohio"	"39"	"21 years"	"21"	146578
+	"Ohio"	"39"	"22 years"	"22"	151129
+	"Ohio"	"39"	"23 years"	"23"	151854
+	"Ohio"	"39"	"24 years"	"24"	149866
+	"Ohio"	"39"	"25 years"	"25"	149256
+	"Ohio"	"39"	"26 years"	"26"	148556
+	"Ohio"	"39"	"27 years"	"27"	149426
+	"Ohio"	"39"	"28 years"	"28"	151522
+	"Ohio"	"39"	"29 years"	"29"	154051
+	"Ohio"	"39"	"30 years"	"30"	156896
+	"Ohio"	"39"	"31 years"	"31"	160408
+	"Ohio"	"39"	"32 years"	"32"	162042
+	"Ohio"	"39"	"33 years"	"33"	162031
+	"Ohio"	"39"	"34 years"	"34"	158075
+	"Ohio"	"39"	"35 years"	"35"	153137
+	"Ohio"	"39"	"36 years"	"36"	150636
+	"Ohio"	"39"	"37 years"	"37"	150834
+	"Ohio"	"39"	"38 years"	"38"	149906
+	"Ohio"	"39"	"39 years"	"39"	145584
+	"Ohio"	"39"	"40 years"	"40"	147746
+	"Ohio"	"39"	"41 years"	"41"	148991
+	"Ohio"	"39"	"42 years"	"42"	147982
+	"Ohio"	"39"	"43 years"	"43"	147574
+	"Ohio"	"39"	"44 years"	"44"	142253
+	"Ohio"	"39"	"45 years"	"45"	138131
+	"Ohio"	"39"	"46 years"	"46"	136018
+	"Ohio"	"39"	"47 years"	"47"	130979
+	"Ohio"	"39"	"48 years"	"48"	133444
+	"Ohio"	"39"	"49 years"	"49"	131094
+	"Ohio"	"39"	"50 years"	"50"	133996
+	"Ohio"	"39"	"51 years"	"51"	143401
+	"Ohio"	"39"	"52 years"	"52"	154444
+	"Ohio"	"39"	"53 years"	"53"	150854
+	"Ohio"	"39"	"54 years"	"54"	144823
+	"Ohio"	"39"	"55 years"	"55"	141374
+	"Ohio"	"39"	"56 years"	"56"	143085
+	"Ohio"	"39"	"57 years"	"57"	144934
+	"Ohio"	"39"	"58 years"	"58"	150849
+	"Ohio"	"39"	"59 years"	"59"	155263
+	"Ohio"	"39"	"60 years"	"60"	155765
+	"Ohio"	"39"	"61 years"	"61"	157777
+	"Ohio"	"39"	"62 years"	"62"	159326
+	"Ohio"	"39"	"63 years"	"63"	155800
+	"Ohio"	"39"	"64 years"	"64"	155657
+	"Ohio"	"39"	"65 years"	"65"	156005
+	"Ohio"	"39"	"66 years"	"66"	152879
+	"Ohio"	"39"	"67 years"	"67"	144668
+	"Ohio"	"39"	"68 years"	"68"	140806
+	"Ohio"	"39"	"69 years"	"69"	134892
+	"Ohio"	"39"	"70 years"	"70"	128314
+	"Ohio"	"39"	"71 years"	"71"	123710
+	"Ohio"	"39"	"72 years"	"72"	116794
+	"Ohio"	"39"	"73 years"	"73"	109455
+	"Ohio"	"39"	"74 years"	"74"	106296
+	"Ohio"	"39"	"75 years"	"75"	102719
+	"Ohio"	"39"	"76 years"	"76"	108326
+	"Ohio"	"39"	"77 years"	"77"	71932
+	"Ohio"	"39"	"78 years"	"78"	66334
+	"Ohio"	"39"	"79 years"	"79"	63949
+	"Ohio"	"39"	"80 years"	"80"	65992
+	"Ohio"	"39"	"81 years"	"81"	56354
+	"Ohio"	"39"	"82 years"	"82"	49464
+	"Ohio"	"39"	"83 years"	"83"	43830
+	"Ohio"	"39"	"84 years"	"84"	39683
+	"Ohio"	"39"	"85+ years"	"85+"	226548
+"Total"	"Ohio"	"39"			11785935
+	"Oklahoma"	"40"	"< 1 year"	"0"	47714
+	"Oklahoma"	"40"	"1 year"	"1"	48302
+	"Oklahoma"	"40"	"2 years"	"2"	48091
+	"Oklahoma"	"40"	"3 years"	"3"	49622
+	"Oklahoma"	"40"	"4 years"	"4"	50548
+	"Oklahoma"	"40"	"5 years"	"5"	51880
+	"Oklahoma"	"40"	"6 years"	"6"	53256
+	"Oklahoma"	"40"	"7 years"	"7"	54670
+	"Oklahoma"	"40"	"8 years"	"8"	54982
+	"Oklahoma"	"40"	"9 years"	"9"	55313
+	"Oklahoma"	"40"	"10 years"	"10"	55157
+	"Oklahoma"	"40"	"11 years"	"11"	54939
+	"Oklahoma"	"40"	"12 years"	"12"	55034
+	"Oklahoma"	"40"	"13 years"	"13"	56005
+	"Oklahoma"	"40"	"14 years"	"14"	56985
+	"Oklahoma"	"40"	"15 years"	"15"	58868
+	"Oklahoma"	"40"	"16 years"	"16"	58428
+	"Oklahoma"	"40"	"17 years"	"17"	56813
+	"Oklahoma"	"40"	"18 years"	"18"	54482
+	"Oklahoma"	"40"	"19 years"	"19"	56948
+	"Oklahoma"	"40"	"20 years"	"20"	57268
+	"Oklahoma"	"40"	"21 years"	"21"	56820
+	"Oklahoma"	"40"	"22 years"	"22"	58134
+	"Oklahoma"	"40"	"23 years"	"23"	57611
+	"Oklahoma"	"40"	"24 years"	"24"	56494
+	"Oklahoma"	"40"	"25 years"	"25"	55034
+	"Oklahoma"	"40"	"26 years"	"26"	53545
+	"Oklahoma"	"40"	"27 years"	"27"	52529
+	"Oklahoma"	"40"	"28 years"	"28"	53105
+	"Oklahoma"	"40"	"29 years"	"29"	53706
+	"Oklahoma"	"40"	"30 years"	"30"	54643
+	"Oklahoma"	"40"	"31 years"	"31"	56683
+	"Oklahoma"	"40"	"32 years"	"32"	56956
+	"Oklahoma"	"40"	"33 years"	"33"	56375
+	"Oklahoma"	"40"	"34 years"	"34"	54508
+	"Oklahoma"	"40"	"35 years"	"35"	53259
+	"Oklahoma"	"40"	"36 years"	"36"	52816
+	"Oklahoma"	"40"	"37 years"	"37"	53892
+	"Oklahoma"	"40"	"38 years"	"38"	54511
+	"Oklahoma"	"40"	"39 years"	"39"	54261
+	"Oklahoma"	"40"	"40 years"	"40"	55358
+	"Oklahoma"	"40"	"41 years"	"41"	54896
+	"Oklahoma"	"40"	"42 years"	"42"	53536
+	"Oklahoma"	"40"	"43 years"	"43"	52999
+	"Oklahoma"	"40"	"44 years"	"44"	50044
+	"Oklahoma"	"40"	"45 years"	"45"	47971
+	"Oklahoma"	"40"	"46 years"	"46"	47207
+	"Oklahoma"	"40"	"47 years"	"47"	45548
+	"Oklahoma"	"40"	"48 years"	"48"	45912
+	"Oklahoma"	"40"	"49 years"	"49"	44146
+	"Oklahoma"	"40"	"50 years"	"50"	44707
+	"Oklahoma"	"40"	"51 years"	"51"	46365
+	"Oklahoma"	"40"	"52 years"	"52"	48811
+	"Oklahoma"	"40"	"53 years"	"53"	47362
+	"Oklahoma"	"40"	"54 years"	"54"	45082
+	"Oklahoma"	"40"	"55 years"	"55"	43160
+	"Oklahoma"	"40"	"56 years"	"56"	43109
+	"Oklahoma"	"40"	"57 years"	"57"	43938
+	"Oklahoma"	"40"	"58 years"	"58"	46398
+	"Oklahoma"	"40"	"59 years"	"59"	48177
+	"Oklahoma"	"40"	"60 years"	"60"	49394
+	"Oklahoma"	"40"	"61 years"	"61"	49873
+	"Oklahoma"	"40"	"62 years"	"62"	49654
+	"Oklahoma"	"40"	"63 years"	"63"	48840
+	"Oklahoma"	"40"	"64 years"	"64"	47512
+	"Oklahoma"	"40"	"65 years"	"65"	46960
+	"Oklahoma"	"40"	"66 years"	"66"	46110
+	"Oklahoma"	"40"	"67 years"	"67"	44128
+	"Oklahoma"	"40"	"68 years"	"68"	42935
+	"Oklahoma"	"40"	"69 years"	"69"	41359
+	"Oklahoma"	"40"	"70 years"	"70"	39347
+	"Oklahoma"	"40"	"71 years"	"71"	37172
+	"Oklahoma"	"40"	"72 years"	"72"	35069
+	"Oklahoma"	"40"	"73 years"	"73"	32931
+	"Oklahoma"	"40"	"74 years"	"74"	31828
+	"Oklahoma"	"40"	"75 years"	"75"	30802
+	"Oklahoma"	"40"	"76 years"	"76"	32466
+	"Oklahoma"	"40"	"77 years"	"77"	22381
+	"Oklahoma"	"40"	"78 years"	"78"	21965
+	"Oklahoma"	"40"	"79 years"	"79"	21349
+	"Oklahoma"	"40"	"80 years"	"80"	20601
+	"Oklahoma"	"40"	"81 years"	"81"	17180
+	"Oklahoma"	"40"	"82 years"	"82"	15321
+	"Oklahoma"	"40"	"83 years"	"83"	13855
+	"Oklahoma"	"40"	"84 years"	"84"	12527
+	"Oklahoma"	"40"	"85+ years"	"85+"	67352
+"Total"	"Oklahoma"	"40"			4053824
+	"Oregon"	"41"	"< 1 year"	"0"	38904
+	"Oregon"	"41"	"1 year"	"1"	40658
+	"Oregon"	"41"	"2 years"	"2"	39367
+	"Oregon"	"41"	"3 years"	"3"	41506
+	"Oregon"	"41"	"4 years"	"4"	41897
+	"Oregon"	"41"	"5 years"	"5"	43343
+	"Oregon"	"41"	"6 years"	"6"	44859
+	"Oregon"	"41"	"7 years"	"7"	46764
+	"Oregon"	"41"	"8 years"	"8"	47494
+	"Oregon"	"41"	"9 years"	"9"	47660
+	"Oregon"	"41"	"10 years"	"10"	47383
+	"Oregon"	"41"	"11 years"	"11"	47807
+	"Oregon"	"41"	"12 years"	"12"	48150
+	"Oregon"	"41"	"13 years"	"13"	49375
+	"Oregon"	"41"	"14 years"	"14"	50437
+	"Oregon"	"41"	"15 years"	"15"	52576
+	"Oregon"	"41"	"16 years"	"16"	52324
+	"Oregon"	"41"	"17 years"	"17"	51326
+	"Oregon"	"41"	"18 years"	"18"	49616
+	"Oregon"	"41"	"19 years"	"19"	49169
+	"Oregon"	"41"	"20 years"	"20"	49869
+	"Oregon"	"41"	"21 years"	"21"	50518
+	"Oregon"	"41"	"22 years"	"22"	52407
+	"Oregon"	"41"	"23 years"	"23"	53222
+	"Oregon"	"41"	"24 years"	"24"	52967
+	"Oregon"	"41"	"25 years"	"25"	53680
+	"Oregon"	"41"	"26 years"	"26"	54575
+	"Oregon"	"41"	"27 years"	"27"	55419
+	"Oregon"	"41"	"28 years"	"28"	56782
+	"Oregon"	"41"	"29 years"	"29"	58029
+	"Oregon"	"41"	"30 years"	"30"	59614
+	"Oregon"	"41"	"31 years"	"31"	61817
+	"Oregon"	"41"	"32 years"	"32"	63779
+	"Oregon"	"41"	"33 years"	"33"	63982
+	"Oregon"	"41"	"34 years"	"34"	61715
+	"Oregon"	"41"	"35 years"	"35"	60656
+	"Oregon"	"41"	"36 years"	"36"	59993
+	"Oregon"	"41"	"37 years"	"37"	60189
+	"Oregon"	"41"	"38 years"	"38"	60412
+	"Oregon"	"41"	"39 years"	"39"	59251
+	"Oregon"	"41"	"40 years"	"40"	60600
+	"Oregon"	"41"	"41 years"	"41"	60347
+	"Oregon"	"41"	"42 years"	"42"	59603
+	"Oregon"	"41"	"43 years"	"43"	58892
+	"Oregon"	"41"	"44 years"	"44"	56491
+	"Oregon"	"41"	"45 years"	"45"	55121
+	"Oregon"	"41"	"46 years"	"46"	54141
+	"Oregon"	"41"	"47 years"	"47"	51943
+	"Oregon"	"41"	"48 years"	"48"	51703
+	"Oregon"	"41"	"49 years"	"49"	49962
+	"Oregon"	"41"	"50 years"	"50"	49486
+	"Oregon"	"41"	"51 years"	"51"	51188
+	"Oregon"	"41"	"52 years"	"52"	54612
+	"Oregon"	"41"	"53 years"	"53"	53728
+	"Oregon"	"41"	"54 years"	"54"	51415
+	"Oregon"	"41"	"55 years"	"55"	48658
+	"Oregon"	"41"	"56 years"	"56"	47953
+	"Oregon"	"41"	"57 years"	"57"	47994
+	"Oregon"	"41"	"58 years"	"58"	49160
+	"Oregon"	"41"	"59 years"	"59"	50474
+	"Oregon"	"41"	"60 years"	"60"	51395
+	"Oregon"	"41"	"61 years"	"61"	52211
+	"Oregon"	"41"	"62 years"	"62"	53173
+	"Oregon"	"41"	"63 years"	"63"	52438
+	"Oregon"	"41"	"64 years"	"64"	51905
+	"Oregon"	"41"	"65 years"	"65"	52652
+	"Oregon"	"41"	"66 years"	"66"	52888
+	"Oregon"	"41"	"67 years"	"67"	51553
+	"Oregon"	"41"	"68 years"	"68"	51523
+	"Oregon"	"41"	"69 years"	"69"	51443
+	"Oregon"	"41"	"70 years"	"70"	50473
+	"Oregon"	"41"	"71 years"	"71"	48686
+	"Oregon"	"41"	"72 years"	"72"	46079
+	"Oregon"	"41"	"73 years"	"73"	43537
+	"Oregon"	"41"	"74 years"	"74"	42108
+	"Oregon"	"41"	"75 years"	"75"	40583
+	"Oregon"	"41"	"76 years"	"76"	42567
+	"Oregon"	"41"	"77 years"	"77"	28900
+	"Oregon"	"41"	"78 years"	"78"	27510
+	"Oregon"	"41"	"79 years"	"79"	26257
+	"Oregon"	"41"	"80 years"	"80"	25689
+	"Oregon"	"41"	"81 years"	"81"	20976
+	"Oregon"	"41"	"82 years"	"82"	18288
+	"Oregon"	"41"	"83 years"	"83"	16231
+	"Oregon"	"41"	"84 years"	"84"	14323
+	"Oregon"	"41"	"85+ years"	"85+"	77008
+"Total"	"Oregon"	"41"			4233358
+	"Pennsylvania"	"42"	"< 1 year"	"0"	128878
+	"Pennsylvania"	"42"	"1 year"	"1"	131810
+	"Pennsylvania"	"42"	"2 years"	"2"	130769
+	"Pennsylvania"	"42"	"3 years"	"3"	136329
+	"Pennsylvania"	"42"	"4 years"	"4"	138121
+	"Pennsylvania"	"42"	"5 years"	"5"	141068
+	"Pennsylvania"	"42"	"6 years"	"6"	143054
+	"Pennsylvania"	"42"	"7 years"	"7"	146199
+	"Pennsylvania"	"42"	"8 years"	"8"	147975
+	"Pennsylvania"	"42"	"9 years"	"9"	148046
+	"Pennsylvania"	"42"	"10 years"	"10"	147718
+	"Pennsylvania"	"42"	"11 years"	"11"	148345
+	"Pennsylvania"	"42"	"12 years"	"12"	149443
+	"Pennsylvania"	"42"	"13 years"	"13"	152398
+	"Pennsylvania"	"42"	"14 years"	"14"	155977
+	"Pennsylvania"	"42"	"15 years"	"15"	161267
+	"Pennsylvania"	"42"	"16 years"	"16"	161567
+	"Pennsylvania"	"42"	"17 years"	"17"	160041
+	"Pennsylvania"	"42"	"18 years"	"18"	172891
+	"Pennsylvania"	"42"	"19 years"	"19"	186857
+	"Pennsylvania"	"42"	"20 years"	"20"	173661
+	"Pennsylvania"	"42"	"21 years"	"21"	164521
+	"Pennsylvania"	"42"	"22 years"	"22"	159455
+	"Pennsylvania"	"42"	"23 years"	"23"	154377
+	"Pennsylvania"	"42"	"24 years"	"24"	152432
+	"Pennsylvania"	"42"	"25 years"	"25"	152037
+	"Pennsylvania"	"42"	"26 years"	"26"	154474
+	"Pennsylvania"	"42"	"27 years"	"27"	157575
+	"Pennsylvania"	"42"	"28 years"	"28"	161218
+	"Pennsylvania"	"42"	"29 years"	"29"	165204
+	"Pennsylvania"	"42"	"30 years"	"30"	168741
+	"Pennsylvania"	"42"	"31 years"	"31"	172432
+	"Pennsylvania"	"42"	"32 years"	"32"	175159
+	"Pennsylvania"	"42"	"33 years"	"33"	178836
+	"Pennsylvania"	"42"	"34 years"	"34"	177488
+	"Pennsylvania"	"42"	"35 years"	"35"	174658
+	"Pennsylvania"	"42"	"36 years"	"36"	171678
+	"Pennsylvania"	"42"	"37 years"	"37"	170507
+	"Pennsylvania"	"42"	"38 years"	"38"	167927
+	"Pennsylvania"	"42"	"39 years"	"39"	162990
+	"Pennsylvania"	"42"	"40 years"	"40"	164331
+	"Pennsylvania"	"42"	"41 years"	"41"	163927
+	"Pennsylvania"	"42"	"42 years"	"42"	160752
+	"Pennsylvania"	"42"	"43 years"	"43"	159272
+	"Pennsylvania"	"42"	"44 years"	"44"	153114
+	"Pennsylvania"	"42"	"45 years"	"45"	149927
+	"Pennsylvania"	"42"	"46 years"	"46"	147459
+	"Pennsylvania"	"42"	"47 years"	"47"	141413
+	"Pennsylvania"	"42"	"48 years"	"48"	143461
+	"Pennsylvania"	"42"	"49 years"	"49"	141877
+	"Pennsylvania"	"42"	"50 years"	"50"	146155
+	"Pennsylvania"	"42"	"51 years"	"51"	156332
+	"Pennsylvania"	"42"	"52 years"	"52"	168423
+	"Pennsylvania"	"42"	"53 years"	"53"	165967
+	"Pennsylvania"	"42"	"54 years"	"54"	162066
+	"Pennsylvania"	"42"	"55 years"	"55"	160478
+	"Pennsylvania"	"42"	"56 years"	"56"	164064
+	"Pennsylvania"	"42"	"57 years"	"57"	166937
+	"Pennsylvania"	"42"	"58 years"	"58"	173859
+	"Pennsylvania"	"42"	"59 years"	"59"	177945
+	"Pennsylvania"	"42"	"60 years"	"60"	177667
+	"Pennsylvania"	"42"	"61 years"	"61"	179285
+	"Pennsylvania"	"42"	"62 years"	"62"	181173
+	"Pennsylvania"	"42"	"63 years"	"63"	178189
+	"Pennsylvania"	"42"	"64 years"	"64"	177813
+	"Pennsylvania"	"42"	"65 years"	"65"	178471
+	"Pennsylvania"	"42"	"66 years"	"66"	174575
+	"Pennsylvania"	"42"	"67 years"	"67"	165473
+	"Pennsylvania"	"42"	"68 years"	"68"	161024
+	"Pennsylvania"	"42"	"69 years"	"69"	155428
+	"Pennsylvania"	"42"	"70 years"	"70"	149078
+	"Pennsylvania"	"42"	"71 years"	"71"	142952
+	"Pennsylvania"	"42"	"72 years"	"72"	133970
+	"Pennsylvania"	"42"	"73 years"	"73"	124983
+	"Pennsylvania"	"42"	"74 years"	"74"	121412
+	"Pennsylvania"	"42"	"75 years"	"75"	119006
+	"Pennsylvania"	"42"	"76 years"	"76"	126010
+	"Pennsylvania"	"42"	"77 years"	"77"	84982
+	"Pennsylvania"	"42"	"78 years"	"78"	79657
+	"Pennsylvania"	"42"	"79 years"	"79"	78117
+	"Pennsylvania"	"42"	"80 years"	"80"	80393
+	"Pennsylvania"	"42"	"81 years"	"81"	67573
+	"Pennsylvania"	"42"	"82 years"	"82"	59228
+	"Pennsylvania"	"42"	"83 years"	"83"	52581
+	"Pennsylvania"	"42"	"84 years"	"84"	48268
+	"Pennsylvania"	"42"	"85+ years"	"85+"	292493
+"Total"	"Pennsylvania"	"42"			12961683
+	"Rhode Island"	"44"	"< 1 year"	"0"	10018
+	"Rhode Island"	"44"	"1 year"	"1"	10520
+	"Rhode Island"	"44"	"2 years"	"2"	10080
+	"Rhode Island"	"44"	"3 years"	"3"	10672
+	"Rhode Island"	"44"	"4 years"	"4"	10920
+	"Rhode Island"	"44"	"5 years"	"5"	11011
+	"Rhode Island"	"44"	"6 years"	"6"	11225
+	"Rhode Island"	"44"	"7 years"	"7"	11443
+	"Rhode Island"	"44"	"8 years"	"8"	11355
+	"Rhode Island"	"44"	"9 years"	"9"	11315
+	"Rhode Island"	"44"	"10 years"	"10"	11300
+	"Rhode Island"	"44"	"11 years"	"11"	11325
+	"Rhode Island"	"44"	"12 years"	"12"	11396
+	"Rhode Island"	"44"	"13 years"	"13"	11597
+	"Rhode Island"	"44"	"14 years"	"14"	11778
+	"Rhode Island"	"44"	"15 years"	"15"	12446
+	"Rhode Island"	"44"	"16 years"	"16"	12645
+	"Rhode Island"	"44"	"17 years"	"17"	12792
+	"Rhode Island"	"44"	"18 years"	"18"	16339
+	"Rhode Island"	"44"	"19 years"	"19"	18163
+	"Rhode Island"	"44"	"20 years"	"20"	16978
+	"Rhode Island"	"44"	"21 years"	"21"	15705
+	"Rhode Island"	"44"	"22 years"	"22"	14400
+	"Rhode Island"	"44"	"23 years"	"23"	13648
+	"Rhode Island"	"44"	"24 years"	"24"	13578
+	"Rhode Island"	"44"	"25 years"	"25"	13578
+	"Rhode Island"	"44"	"26 years"	"26"	13875
+	"Rhode Island"	"44"	"27 years"	"27"	14059
+	"Rhode Island"	"44"	"28 years"	"28"	14656
+	"Rhode Island"	"44"	"29 years"	"29"	15082
+	"Rhode Island"	"44"	"30 years"	"30"	15469
+	"Rhode Island"	"44"	"31 years"	"31"	15490
+	"Rhode Island"	"44"	"32 years"	"32"	16044
+	"Rhode Island"	"44"	"33 years"	"33"	16320
+	"Rhode Island"	"44"	"34 years"	"34"	16000
+	"Rhode Island"	"44"	"35 years"	"35"	15541
+	"Rhode Island"	"44"	"36 years"	"36"	15053
+	"Rhode Island"	"44"	"37 years"	"37"	14566
+	"Rhode Island"	"44"	"38 years"	"38"	14368
+	"Rhode Island"	"44"	"39 years"	"39"	14040
+	"Rhode Island"	"44"	"40 years"	"40"	13953
+	"Rhode Island"	"44"	"41 years"	"41"	14042
+	"Rhode Island"	"44"	"42 years"	"42"	13857
+	"Rhode Island"	"44"	"43 years"	"43"	13634
+	"Rhode Island"	"44"	"44 years"	"44"	12951
+	"Rhode Island"	"44"	"45 years"	"45"	12528
+	"Rhode Island"	"44"	"46 years"	"46"	12297
+	"Rhode Island"	"44"	"47 years"	"47"	11727
+	"Rhode Island"	"44"	"48 years"	"48"	11975
+	"Rhode Island"	"44"	"49 years"	"49"	11959
+	"Rhode Island"	"44"	"50 years"	"50"	12274
+	"Rhode Island"	"44"	"51 years"	"51"	13160
+	"Rhode Island"	"44"	"52 years"	"52"	14087
+	"Rhode Island"	"44"	"53 years"	"53"	14167
+	"Rhode Island"	"44"	"54 years"	"54"	13987
+	"Rhode Island"	"44"	"55 years"	"55"	14135
+	"Rhode Island"	"44"	"56 years"	"56"	14637
+	"Rhode Island"	"44"	"57 years"	"57"	14894
+	"Rhode Island"	"44"	"58 years"	"58"	15538
+	"Rhode Island"	"44"	"59 years"	"59"	15544
+	"Rhode Island"	"44"	"60 years"	"60"	15362
+	"Rhode Island"	"44"	"61 years"	"61"	15624
+	"Rhode Island"	"44"	"62 years"	"62"	15483
+	"Rhode Island"	"44"	"63 years"	"63"	14998
+	"Rhode Island"	"44"	"64 years"	"64"	14811
+	"Rhode Island"	"44"	"65 years"	"65"	14896
+	"Rhode Island"	"44"	"66 years"	"66"	14551
+	"Rhode Island"	"44"	"67 years"	"67"	13839
+	"Rhode Island"	"44"	"68 years"	"68"	13343
+	"Rhode Island"	"44"	"69 years"	"69"	12631
+	"Rhode Island"	"44"	"70 years"	"70"	11951
+	"Rhode Island"	"44"	"71 years"	"71"	11404
+	"Rhode Island"	"44"	"72 years"	"72"	10742
+	"Rhode Island"	"44"	"73 years"	"73"	10196
+	"Rhode Island"	"44"	"74 years"	"74"	9805
+	"Rhode Island"	"44"	"75 years"	"75"	9502
+	"Rhode Island"	"44"	"76 years"	"76"	10080
+	"Rhode Island"	"44"	"77 years"	"77"	6968
+	"Rhode Island"	"44"	"78 years"	"78"	6588
+	"Rhode Island"	"44"	"79 years"	"79"	6344
+	"Rhode Island"	"44"	"80 years"	"80"	6415
+	"Rhode Island"	"44"	"81 years"	"81"	5322
+	"Rhode Island"	"44"	"82 years"	"82"	4672
+	"Rhode Island"	"44"	"83 years"	"83"	4138
+	"Rhode Island"	"44"	"84 years"	"84"	3835
+	"Rhode Island"	"44"	"85+ years"	"85+"	24326
+"Total"	"Rhode Island"	"44"			1095962
+	"South Carolina"	"45"	"< 1 year"	"0"	57279
+	"South Carolina"	"45"	"1 year"	"1"	58227
+	"South Carolina"	"45"	"2 years"	"2"	58104
+	"South Carolina"	"45"	"3 years"	"3"	58636
+	"South Carolina"	"45"	"4 years"	"4"	59366
+	"South Carolina"	"45"	"5 years"	"5"	60746
+	"South Carolina"	"45"	"6 years"	"6"	61512
+	"South Carolina"	"45"	"7 years"	"7"	63186
+	"South Carolina"	"45"	"8 years"	"8"	63844
+	"South Carolina"	"45"	"9 years"	"9"	63856
+	"South Carolina"	"45"	"10 years"	"10"	63365
+	"South Carolina"	"45"	"11 years"	"11"	63781
+	"South Carolina"	"45"	"12 years"	"12"	64599
+	"South Carolina"	"45"	"13 years"	"13"	66993
+	"South Carolina"	"45"	"14 years"	"14"	69165
+	"South Carolina"	"45"	"15 years"	"15"	71581
+	"South Carolina"	"45"	"16 years"	"16"	71128
+	"South Carolina"	"45"	"17 years"	"17"	68833
+	"South Carolina"	"45"	"18 years"	"18"	70002
+	"South Carolina"	"45"	"19 years"	"19"	73457
+	"South Carolina"	"45"	"20 years"	"20"	69272
+	"South Carolina"	"45"	"21 years"	"21"	68762
+	"South Carolina"	"45"	"22 years"	"22"	69476
+	"South Carolina"	"45"	"23 years"	"23"	68972
+	"South Carolina"	"45"	"24 years"	"24"	66874
+	"South Carolina"	"45"	"25 years"	"25"	66156
+	"South Carolina"	"45"	"26 years"	"26"	65226
+	"South Carolina"	"45"	"27 years"	"27"	65098
+	"South Carolina"	"45"	"28 years"	"28"	66113
+	"South Carolina"	"45"	"29 years"	"29"	67653
+	"South Carolina"	"45"	"30 years"	"30"	68788
+	"South Carolina"	"45"	"31 years"	"31"	71265
+	"South Carolina"	"45"	"32 years"	"32"	73528
+	"South Carolina"	"45"	"33 years"	"33"	73896
+	"South Carolina"	"45"	"34 years"	"34"	71763
+	"South Carolina"	"45"	"35 years"	"35"	69692
+	"South Carolina"	"45"	"36 years"	"36"	67691
+	"South Carolina"	"45"	"37 years"	"37"	67351
+	"South Carolina"	"45"	"38 years"	"38"	67294
+	"South Carolina"	"45"	"39 years"	"39"	66347
+	"South Carolina"	"45"	"40 years"	"40"	67547
+	"South Carolina"	"45"	"41 years"	"41"	67780
+	"South Carolina"	"45"	"42 years"	"42"	66968
+	"South Carolina"	"45"	"43 years"	"43"	66519
+	"South Carolina"	"45"	"44 years"	"44"	64302
+	"South Carolina"	"45"	"45 years"	"45"	63289
+	"South Carolina"	"45"	"46 years"	"46"	62408
+	"South Carolina"	"45"	"47 years"	"47"	59726
+	"South Carolina"	"45"	"48 years"	"48"	61192
+	"South Carolina"	"45"	"49 years"	"49"	60782
+	"South Carolina"	"45"	"50 years"	"50"	62663
+	"South Carolina"	"45"	"51 years"	"51"	66121
+	"South Carolina"	"45"	"52 years"	"52"	70240
+	"South Carolina"	"45"	"53 years"	"53"	68775
+	"South Carolina"	"45"	"54 years"	"54"	66081
+	"South Carolina"	"45"	"55 years"	"55"	64980
+	"South Carolina"	"45"	"56 years"	"56"	66039
+	"South Carolina"	"45"	"57 years"	"57"	67737
+	"South Carolina"	"45"	"58 years"	"58"	70678
+	"South Carolina"	"45"	"59 years"	"59"	72611
+	"South Carolina"	"45"	"60 years"	"60"	72428
+	"South Carolina"	"45"	"61 years"	"61"	72853
+	"South Carolina"	"45"	"62 years"	"62"	72864
+	"South Carolina"	"45"	"63 years"	"63"	71559
+	"South Carolina"	"45"	"64 years"	"64"	70605
+	"South Carolina"	"45"	"65 years"	"65"	70447
+	"South Carolina"	"45"	"66 years"	"66"	69998
+	"South Carolina"	"45"	"67 years"	"67"	67288
+	"South Carolina"	"45"	"68 years"	"68"	66001
+	"South Carolina"	"45"	"69 years"	"69"	63957
+	"South Carolina"	"45"	"70 years"	"70"	61087
+	"South Carolina"	"45"	"71 years"	"71"	58938
+	"South Carolina"	"45"	"72 years"	"72"	56368
+	"South Carolina"	"45"	"73 years"	"73"	53505
+	"South Carolina"	"45"	"74 years"	"74"	52219
+	"South Carolina"	"45"	"75 years"	"75"	51201
+	"South Carolina"	"45"	"76 years"	"76"	53950
+	"South Carolina"	"45"	"77 years"	"77"	36862
+	"South Carolina"	"45"	"78 years"	"78"	34935
+	"South Carolina"	"45"	"79 years"	"79"	32996
+	"South Carolina"	"45"	"80 years"	"80"	32128
+	"South Carolina"	"45"	"81 years"	"81"	26161
+	"South Carolina"	"45"	"82 years"	"82"	22838
+	"South Carolina"	"45"	"83 years"	"83"	20030
+	"South Carolina"	"45"	"84 years"	"84"	17453
+	"South Carolina"	"45"	"85+ years"	"85+"	89569
+"Total"	"South Carolina"	"45"			5373555
+	"South Dakota"	"46"	"< 1 year"	"0"	11434
+	"South Dakota"	"46"	"1 year"	"1"	11506
+	"South Dakota"	"46"	"2 years"	"2"	11212
+	"South Dakota"	"46"	"3 years"	"3"	11819
+	"South Dakota"	"46"	"4 years"	"4"	11964
+	"South Dakota"	"46"	"5 years"	"5"	12299
+	"South Dakota"	"46"	"6 years"	"6"	12375
+	"South Dakota"	"46"	"7 years"	"7"	12614
+	"South Dakota"	"46"	"8 years"	"8"	12531
+	"South Dakota"	"46"	"9 years"	"9"	12520
+	"South Dakota"	"46"	"10 years"	"10"	12481
+	"South Dakota"	"46"	"11 years"	"11"	12367
+	"South Dakota"	"46"	"12 years"	"12"	12415
+	"South Dakota"	"46"	"13 years"	"13"	12607
+	"South Dakota"	"46"	"14 years"	"14"	12837
+	"South Dakota"	"46"	"15 years"	"15"	13244
+	"South Dakota"	"46"	"16 years"	"16"	13066
+	"South Dakota"	"46"	"17 years"	"17"	12607
+	"South Dakota"	"46"	"18 years"	"18"	11718
+	"South Dakota"	"46"	"19 years"	"19"	12656
+	"South Dakota"	"46"	"20 years"	"20"	12346
+	"South Dakota"	"46"	"21 years"	"21"	12115
+	"South Dakota"	"46"	"22 years"	"22"	12444
+	"South Dakota"	"46"	"23 years"	"23"	12362
+	"South Dakota"	"46"	"24 years"	"24"	11786
+	"South Dakota"	"46"	"25 years"	"25"	11522
+	"South Dakota"	"46"	"26 years"	"26"	11428
+	"South Dakota"	"46"	"27 years"	"27"	11331
+	"South Dakota"	"46"	"28 years"	"28"	11316
+	"South Dakota"	"46"	"29 years"	"29"	11440
+	"South Dakota"	"46"	"30 years"	"30"	11617
+	"South Dakota"	"46"	"31 years"	"31"	11833
+	"South Dakota"	"46"	"32 years"	"32"	11569
+	"South Dakota"	"46"	"33 years"	"33"	11593
+	"South Dakota"	"46"	"34 years"	"34"	11538
+	"South Dakota"	"46"	"35 years"	"35"	11626
+	"South Dakota"	"46"	"36 years"	"36"	11782
+	"South Dakota"	"46"	"37 years"	"37"	11789
+	"South Dakota"	"46"	"38 years"	"38"	11981
+	"South Dakota"	"46"	"39 years"	"39"	11782
+	"South Dakota"	"46"	"40 years"	"40"	11789
+	"South Dakota"	"46"	"41 years"	"41"	11789
+	"South Dakota"	"46"	"42 years"	"42"	11820
+	"South Dakota"	"46"	"43 years"	"43"	11651
+	"South Dakota"	"46"	"44 years"	"44"	10876
+	"South Dakota"	"46"	"45 years"	"45"	10415
+	"South Dakota"	"46"	"46 years"	"46"	10244
+	"South Dakota"	"46"	"47 years"	"47"	9685
+	"South Dakota"	"46"	"48 years"	"48"	9588
+	"South Dakota"	"46"	"49 years"	"49"	9191
+	"South Dakota"	"46"	"50 years"	"50"	9189
+	"South Dakota"	"46"	"51 years"	"51"	9527
+	"South Dakota"	"46"	"52 years"	"52"	10047
+	"South Dakota"	"46"	"53 years"	"53"	10103
+	"South Dakota"	"46"	"54 years"	"54"	9686
+	"South Dakota"	"46"	"55 years"	"55"	9563
+	"South Dakota"	"46"	"56 years"	"56"	9853
+	"South Dakota"	"46"	"57 years"	"57"	10274
+	"South Dakota"	"46"	"58 years"	"58"	10828
+	"South Dakota"	"46"	"59 years"	"59"	11588
+	"South Dakota"	"46"	"60 years"	"60"	11901
+	"South Dakota"	"46"	"61 years"	"61"	12305
+	"South Dakota"	"46"	"62 years"	"62"	12536
+	"South Dakota"	"46"	"63 years"	"63"	12409
+	"South Dakota"	"46"	"64 years"	"64"	12152
+	"South Dakota"	"46"	"65 years"	"65"	12242
+	"South Dakota"	"46"	"66 years"	"66"	11905
+	"South Dakota"	"46"	"67 years"	"67"	11496
+	"South Dakota"	"46"	"68 years"	"68"	11327
+	"South Dakota"	"46"	"69 years"	"69"	10979
+	"South Dakota"	"46"	"70 years"	"70"	10306
+	"South Dakota"	"46"	"71 years"	"71"	9771
+	"South Dakota"	"46"	"72 years"	"72"	9198
+	"South Dakota"	"46"	"73 years"	"73"	8382
+	"South Dakota"	"46"	"74 years"	"74"	7858
+	"South Dakota"	"46"	"75 years"	"75"	7409
+	"South Dakota"	"46"	"76 years"	"76"	7340
+	"South Dakota"	"46"	"77 years"	"77"	4986
+	"South Dakota"	"46"	"78 years"	"78"	4737
+	"South Dakota"	"46"	"79 years"	"79"	4602
+	"South Dakota"	"46"	"80 years"	"80"	4573
+	"South Dakota"	"46"	"81 years"	"81"	3788
+	"South Dakota"	"46"	"82 years"	"82"	3271
+	"South Dakota"	"46"	"83 years"	"83"	3040
+	"South Dakota"	"46"	"84 years"	"84"	2886
+	"South Dakota"	"46"	"85+ years"	"85+"	18741
+"Total"	"South Dakota"	"46"			919318
+	"Tennessee"	"47"	"< 1 year"	"0"	81959
+	"Tennessee"	"47"	"1 year"	"1"	82331
+	"Tennessee"	"47"	"2 years"	"2"	80622
+	"Tennessee"	"47"	"3 years"	"3"	82634
+	"Tennessee"	"47"	"4 years"	"4"	83834
+	"Tennessee"	"47"	"5 years"	"5"	85408
+	"Tennessee"	"47"	"6 years"	"6"	85330
+	"Tennessee"	"47"	"7 years"	"7"	87258
+	"Tennessee"	"47"	"8 years"	"8"	87748
+	"Tennessee"	"47"	"9 years"	"9"	87147
+	"Tennessee"	"47"	"10 years"	"10"	86891
+	"Tennessee"	"47"	"11 years"	"11"	86967
+	"Tennessee"	"47"	"12 years"	"12"	86916
+	"Tennessee"	"47"	"13 years"	"13"	88971
+	"Tennessee"	"47"	"14 years"	"14"	91991
+	"Tennessee"	"47"	"15 years"	"15"	96054
+	"Tennessee"	"47"	"16 years"	"16"	95330
+	"Tennessee"	"47"	"17 years"	"17"	93337
+	"Tennessee"	"47"	"18 years"	"18"	86839
+	"Tennessee"	"47"	"19 years"	"19"	85320
+	"Tennessee"	"47"	"20 years"	"20"	87576
+	"Tennessee"	"47"	"21 years"	"21"	89136
+	"Tennessee"	"47"	"22 years"	"22"	92966
+	"Tennessee"	"47"	"23 years"	"23"	96065
+	"Tennessee"	"47"	"24 years"	"24"	96610
+	"Tennessee"	"47"	"25 years"	"25"	95561
+	"Tennessee"	"47"	"26 years"	"26"	95418
+	"Tennessee"	"47"	"27 years"	"27"	95678
+	"Tennessee"	"47"	"28 years"	"28"	97327
+	"Tennessee"	"47"	"29 years"	"29"	98917
+	"Tennessee"	"47"	"30 years"	"30"	99727
+	"Tennessee"	"47"	"31 years"	"31"	101505
+	"Tennessee"	"47"	"32 years"	"32"	103163
+	"Tennessee"	"47"	"33 years"	"33"	101764
+	"Tennessee"	"47"	"34 years"	"34"	98218
+	"Tennessee"	"47"	"35 years"	"35"	94549
+	"Tennessee"	"47"	"36 years"	"36"	92791
+	"Tennessee"	"47"	"37 years"	"37"	92107
+	"Tennessee"	"47"	"38 years"	"38"	91407
+	"Tennessee"	"47"	"39 years"	"39"	89330
+	"Tennessee"	"47"	"40 years"	"40"	91492
+	"Tennessee"	"47"	"41 years"	"41"	91463
+	"Tennessee"	"47"	"42 years"	"42"	90085
+	"Tennessee"	"47"	"43 years"	"43"	90972
+	"Tennessee"	"47"	"44 years"	"44"	87958
+	"Tennessee"	"47"	"45 years"	"45"	86613
+	"Tennessee"	"47"	"46 years"	"46"	85798
+	"Tennessee"	"47"	"47 years"	"47"	82217
+	"Tennessee"	"47"	"48 years"	"48"	84202
+	"Tennessee"	"47"	"49 years"	"49"	83367
+	"Tennessee"	"47"	"50 years"	"50"	85374
+	"Tennessee"	"47"	"51 years"	"51"	90207
+	"Tennessee"	"47"	"52 years"	"52"	96093
+	"Tennessee"	"47"	"53 years"	"53"	93696
+	"Tennessee"	"47"	"54 years"	"54"	89094
+	"Tennessee"	"47"	"55 years"	"55"	86084
+	"Tennessee"	"47"	"56 years"	"56"	86455
+	"Tennessee"	"47"	"57 years"	"57"	88402
+	"Tennessee"	"47"	"58 years"	"58"	92317
+	"Tennessee"	"47"	"59 years"	"59"	94319
+	"Tennessee"	"47"	"60 years"	"60"	93341
+	"Tennessee"	"47"	"61 years"	"61"	92435
+	"Tennessee"	"47"	"62 years"	"62"	91861
+	"Tennessee"	"47"	"63 years"	"63"	89763
+	"Tennessee"	"47"	"64 years"	"64"	88183
+	"Tennessee"	"47"	"65 years"	"65"	87360
+	"Tennessee"	"47"	"66 years"	"66"	85891
+	"Tennessee"	"47"	"67 years"	"67"	81961
+	"Tennessee"	"47"	"68 years"	"68"	79579
+	"Tennessee"	"47"	"69 years"	"69"	77087
+	"Tennessee"	"47"	"70 years"	"70"	72708
+	"Tennessee"	"47"	"71 years"	"71"	69208
+	"Tennessee"	"47"	"72 years"	"72"	65767
+	"Tennessee"	"47"	"73 years"	"73"	62093
+	"Tennessee"	"47"	"74 years"	"74"	60841
+	"Tennessee"	"47"	"75 years"	"75"	59378
+	"Tennessee"	"47"	"76 years"	"76"	62668
+	"Tennessee"	"47"	"77 years"	"77"	42222
+	"Tennessee"	"47"	"78 years"	"78"	40283
+	"Tennessee"	"47"	"79 years"	"79"	38520
+	"Tennessee"	"47"	"80 years"	"80"	38256
+	"Tennessee"	"47"	"81 years"	"81"	31628
+	"Tennessee"	"47"	"82 years"	"82"	27556
+	"Tennessee"	"47"	"83 years"	"83"	24397
+	"Tennessee"	"47"	"84 years"	"84"	21782
+	"Tennessee"	"47"	"85+ years"	"85+"	112811
+"Total"	"Tennessee"	"47"			7126489
+	"Texas"	"48"	"< 1 year"	"0"	389814
+	"Texas"	"48"	"1 year"	"1"	390289
+	"Texas"	"48"	"2 years"	"2"	378282
+	"Texas"	"48"	"3 years"	"3"	385255
+	"Texas"	"48"	"4 years"	"4"	393253
+	"Texas"	"48"	"5 years"	"5"	402314
+	"Texas"	"48"	"6 years"	"6"	413833
+	"Texas"	"48"	"7 years"	"7"	428696
+	"Texas"	"48"	"8 years"	"8"	432975
+	"Texas"	"48"	"9 years"	"9"	430468
+	"Texas"	"48"	"10 years"	"10"	425313
+	"Texas"	"48"	"11 years"	"11"	422015
+	"Texas"	"48"	"12 years"	"12"	427974
+	"Texas"	"48"	"13 years"	"13"	438013
+	"Texas"	"48"	"14 years"	"14"	444953
+	"Texas"	"48"	"15 years"	"15"	458391
+	"Texas"	"48"	"16 years"	"16"	454437
+	"Texas"	"48"	"17 years"	"17"	444850
+	"Texas"	"48"	"18 years"	"18"	425776
+	"Texas"	"48"	"19 years"	"19"	421700
+	"Texas"	"48"	"20 years"	"20"	417202
+	"Texas"	"48"	"21 years"	"21"	416060
+	"Texas"	"48"	"22 years"	"22"	427584
+	"Texas"	"48"	"23 years"	"23"	431915
+	"Texas"	"48"	"24 years"	"24"	425857
+	"Texas"	"48"	"25 years"	"25"	424699
+	"Texas"	"48"	"26 years"	"26"	426755
+	"Texas"	"48"	"27 years"	"27"	427578
+	"Texas"	"48"	"28 years"	"28"	430973
+	"Texas"	"48"	"29 years"	"29"	438694
+	"Texas"	"48"	"30 years"	"30"	445825
+	"Texas"	"48"	"31 years"	"31"	454454
+	"Texas"	"48"	"32 years"	"32"	455255
+	"Texas"	"48"	"33 years"	"33"	454439
+	"Texas"	"48"	"34 years"	"34"	442665
+	"Texas"	"48"	"35 years"	"35"	438529
+	"Texas"	"48"	"36 years"	"36"	438230
+	"Texas"	"48"	"37 years"	"37"	439879
+	"Texas"	"48"	"38 years"	"38"	439642
+	"Texas"	"48"	"39 years"	"39"	431249
+	"Texas"	"48"	"40 years"	"40"	437083
+	"Texas"	"48"	"41 years"	"41"	434869
+	"Texas"	"48"	"42 years"	"42"	425788
+	"Texas"	"48"	"43 years"	"43"	421973
+	"Texas"	"48"	"44 years"	"44"	400694
+	"Texas"	"48"	"45 years"	"45"	390302
+	"Texas"	"48"	"46 years"	"46"	385182
+	"Texas"	"48"	"47 years"	"47"	374244
+	"Texas"	"48"	"48 years"	"48"	374090
+	"Texas"	"48"	"49 years"	"49"	365477
+	"Texas"	"48"	"50 years"	"50"	365102
+	"Texas"	"48"	"51 years"	"51"	375200
+	"Texas"	"48"	"52 years"	"52"	386057
+	"Texas"	"48"	"53 years"	"53"	372117
+	"Texas"	"48"	"54 years"	"54"	351589
+	"Texas"	"48"	"55 years"	"55"	339701
+	"Texas"	"48"	"56 years"	"56"	332203
+	"Texas"	"48"	"57 years"	"57"	331998
+	"Texas"	"48"	"58 years"	"58"	339337
+	"Texas"	"48"	"59 years"	"59"	343369
+	"Texas"	"48"	"60 years"	"60"	341096
+	"Texas"	"48"	"61 years"	"61"	338582
+	"Texas"	"48"	"62 years"	"62"	332498
+	"Texas"	"48"	"63 years"	"63"	325467
+	"Texas"	"48"	"64 years"	"64"	315135
+	"Texas"	"48"	"65 years"	"65"	307747
+	"Texas"	"48"	"66 years"	"66"	298583
+	"Texas"	"48"	"67 years"	"67"	283664
+	"Texas"	"48"	"68 years"	"68"	274007
+	"Texas"	"48"	"69 years"	"69"	260543
+	"Texas"	"48"	"70 years"	"70"	246880
+	"Texas"	"48"	"71 years"	"71"	233852
+	"Texas"	"48"	"72 years"	"72"	220508
+	"Texas"	"48"	"73 years"	"73"	208480
+	"Texas"	"48"	"74 years"	"74"	199776
+	"Texas"	"48"	"75 years"	"75"	192821
+	"Texas"	"48"	"76 years"	"76"	197856
+	"Texas"	"48"	"77 years"	"77"	141374
+	"Texas"	"48"	"78 years"	"78"	133768
+	"Texas"	"48"	"79 years"	"79"	127025
+	"Texas"	"48"	"80 years"	"80"	122250
+	"Texas"	"48"	"81 years"	"81"	102333
+	"Texas"	"48"	"82 years"	"82"	91224
+	"Texas"	"48"	"83 years"	"83"	81241
+	"Texas"	"48"	"84 years"	"84"	72366
+	"Texas"	"48"	"85+ years"	"85+"	391765
+"Total"	"Texas"	"48"			30503301
+	"Utah"	"49"	"< 1 year"	"0"	45759
+	"Utah"	"49"	"1 year"	"1"	45687
+	"Utah"	"49"	"2 years"	"2"	44955
+	"Utah"	"49"	"3 years"	"3"	47273
+	"Utah"	"49"	"4 years"	"4"	47621
+	"Utah"	"49"	"5 years"	"5"	48124
+	"Utah"	"49"	"6 years"	"6"	49802
+	"Utah"	"49"	"7 years"	"7"	51892
+	"Utah"	"49"	"8 years"	"8"	52500
+	"Utah"	"49"	"9 years"	"9"	52739
+	"Utah"	"49"	"10 years"	"10"	53003
+	"Utah"	"49"	"11 years"	"11"	52608
+	"Utah"	"49"	"12 years"	"12"	53629
+	"Utah"	"49"	"13 years"	"13"	55477
+	"Utah"	"49"	"14 years"	"14"	57067
+	"Utah"	"49"	"15 years"	"15"	58947
+	"Utah"	"49"	"16 years"	"16"	58696
+	"Utah"	"49"	"17 years"	"17"	57373
+	"Utah"	"49"	"18 years"	"18"	55226
+	"Utah"	"49"	"19 years"	"19"	52447
+	"Utah"	"49"	"20 years"	"20"	52649
+	"Utah"	"49"	"21 years"	"21"	55735
+	"Utah"	"49"	"22 years"	"22"	60520
+	"Utah"	"49"	"23 years"	"23"	63260
+	"Utah"	"49"	"24 years"	"24"	59997
+	"Utah"	"49"	"25 years"	"25"	56285
+	"Utah"	"49"	"26 years"	"26"	53907
+	"Utah"	"49"	"27 years"	"27"	51864
+	"Utah"	"49"	"28 years"	"28"	50878
+	"Utah"	"49"	"29 years"	"29"	50230
+	"Utah"	"49"	"30 years"	"30"	49499
+	"Utah"	"49"	"31 years"	"31"	50414
+	"Utah"	"49"	"32 years"	"32"	50012
+	"Utah"	"49"	"33 years"	"33"	48713
+	"Utah"	"49"	"34 years"	"34"	47039
+	"Utah"	"49"	"35 years"	"35"	45556
+	"Utah"	"49"	"36 years"	"36"	44109
+	"Utah"	"49"	"37 years"	"37"	44763
+	"Utah"	"49"	"38 years"	"38"	45724
+	"Utah"	"49"	"39 years"	"39"	45946
+	"Utah"	"49"	"40 years"	"40"	47606
+	"Utah"	"49"	"41 years"	"41"	48105
+	"Utah"	"49"	"42 years"	"42"	48112
+	"Utah"	"49"	"43 years"	"43"	48190
+	"Utah"	"49"	"44 years"	"44"	46728
+	"Utah"	"49"	"45 years"	"45"	45941
+	"Utah"	"49"	"46 years"	"46"	44421
+	"Utah"	"49"	"47 years"	"47"	41146
+	"Utah"	"49"	"48 years"	"48"	39491
+	"Utah"	"49"	"49 years"	"49"	37119
+	"Utah"	"49"	"50 years"	"50"	35982
+	"Utah"	"49"	"51 years"	"51"	36150
+	"Utah"	"49"	"52 years"	"52"	36777
+	"Utah"	"49"	"53 years"	"53"	34922
+	"Utah"	"49"	"54 years"	"54"	32971
+	"Utah"	"49"	"55 years"	"55"	31182
+	"Utah"	"49"	"56 years"	"56"	30730
+	"Utah"	"49"	"57 years"	"57"	29860
+	"Utah"	"49"	"58 years"	"58"	30218
+	"Utah"	"49"	"59 years"	"59"	30973
+	"Utah"	"49"	"60 years"	"60"	31341
+	"Utah"	"49"	"61 years"	"61"	31793
+	"Utah"	"49"	"62 years"	"62"	31750
+	"Utah"	"49"	"63 years"	"63"	30830
+	"Utah"	"49"	"64 years"	"64"	30335
+	"Utah"	"49"	"65 years"	"65"	30093
+	"Utah"	"49"	"66 years"	"66"	29548
+	"Utah"	"49"	"67 years"	"67"	28032
+	"Utah"	"49"	"68 years"	"68"	27302
+	"Utah"	"49"	"69 years"	"69"	26387
+	"Utah"	"49"	"70 years"	"70"	25211
+	"Utah"	"49"	"71 years"	"71"	23824
+	"Utah"	"49"	"72 years"	"72"	22244
+	"Utah"	"49"	"73 years"	"73"	20855
+	"Utah"	"49"	"74 years"	"74"	20211
+	"Utah"	"49"	"75 years"	"75"	19343
+	"Utah"	"49"	"76 years"	"76"	19965
+	"Utah"	"49"	"77 years"	"77"	13727
+	"Utah"	"49"	"78 years"	"78"	13190
+	"Utah"	"49"	"79 years"	"79"	12983
+	"Utah"	"49"	"80 years"	"80"	12712
+	"Utah"	"49"	"81 years"	"81"	10417
+	"Utah"	"49"	"82 years"	"82"	9085
+	"Utah"	"49"	"83 years"	"83"	8089
+	"Utah"	"49"	"84 years"	"84"	7283
+	"Utah"	"49"	"85+ years"	"85+"	36635
+"Total"	"Utah"	"49"			3417734
+	"Vermont"	"50"	"< 1 year"	"0"	5112
+	"Vermont"	"50"	"1 year"	"1"	5494
+	"Vermont"	"50"	"2 years"	"2"	5285
+	"Vermont"	"50"	"3 years"	"3"	5654
+	"Vermont"	"50"	"4 years"	"4"	5803
+	"Vermont"	"50"	"5 years"	"5"	5959
+	"Vermont"	"50"	"6 years"	"6"	6170
+	"Vermont"	"50"	"7 years"	"7"	6402
+	"Vermont"	"50"	"8 years"	"8"	6464
+	"Vermont"	"50"	"9 years"	"9"	6653
+	"Vermont"	"50"	"10 years"	"10"	6530
+	"Vermont"	"50"	"11 years"	"11"	6613
+	"Vermont"	"50"	"12 years"	"12"	6681
+	"Vermont"	"50"	"13 years"	"13"	6755
+	"Vermont"	"50"	"14 years"	"14"	6973
+	"Vermont"	"50"	"15 years"	"15"	7338
+	"Vermont"	"50"	"16 years"	"16"	7379
+	"Vermont"	"50"	"17 years"	"17"	7371
+	"Vermont"	"50"	"18 years"	"18"	9087
+	"Vermont"	"50"	"19 years"	"19"	10653
+	"Vermont"	"50"	"20 years"	"20"	10291
+	"Vermont"	"50"	"21 years"	"21"	9535
+	"Vermont"	"50"	"22 years"	"22"	8724
+	"Vermont"	"50"	"23 years"	"23"	7818
+	"Vermont"	"50"	"24 years"	"24"	7407
+	"Vermont"	"50"	"25 years"	"25"	7229
+	"Vermont"	"50"	"26 years"	"26"	7101
+	"Vermont"	"50"	"27 years"	"27"	7185
+	"Vermont"	"50"	"28 years"	"28"	7569
+	"Vermont"	"50"	"29 years"	"29"	7649
+	"Vermont"	"50"	"30 years"	"30"	7938
+	"Vermont"	"50"	"31 years"	"31"	8133
+	"Vermont"	"50"	"32 years"	"32"	8204
+	"Vermont"	"50"	"33 years"	"33"	8180
+	"Vermont"	"50"	"34 years"	"34"	8004
+	"Vermont"	"50"	"35 years"	"35"	8169
+	"Vermont"	"50"	"36 years"	"36"	8106
+	"Vermont"	"50"	"37 years"	"37"	8072
+	"Vermont"	"50"	"38 years"	"38"	8158
+	"Vermont"	"50"	"39 years"	"39"	8127
+	"Vermont"	"50"	"40 years"	"40"	8243
+	"Vermont"	"50"	"41 years"	"41"	8221
+	"Vermont"	"50"	"42 years"	"42"	8028
+	"Vermont"	"50"	"43 years"	"43"	7956
+	"Vermont"	"50"	"44 years"	"44"	7737
+	"Vermont"	"50"	"45 years"	"45"	7561
+	"Vermont"	"50"	"46 years"	"46"	7390
+	"Vermont"	"50"	"47 years"	"47"	7093
+	"Vermont"	"50"	"48 years"	"48"	7174
+	"Vermont"	"50"	"49 years"	"49"	7072
+	"Vermont"	"50"	"50 years"	"50"	7215
+	"Vermont"	"50"	"51 years"	"51"	7674
+	"Vermont"	"50"	"52 years"	"52"	8516
+	"Vermont"	"50"	"53 years"	"53"	8427
+	"Vermont"	"50"	"54 years"	"54"	8245
+	"Vermont"	"50"	"55 years"	"55"	8112
+	"Vermont"	"50"	"56 years"	"56"	8266
+	"Vermont"	"50"	"57 years"	"57"	8467
+	"Vermont"	"50"	"58 years"	"58"	9016
+	"Vermont"	"50"	"59 years"	"59"	9313
+	"Vermont"	"50"	"60 years"	"60"	9521
+	"Vermont"	"50"	"61 years"	"61"	9737
+	"Vermont"	"50"	"62 years"	"62"	9934
+	"Vermont"	"50"	"63 years"	"63"	9736
+	"Vermont"	"50"	"64 years"	"64"	9712
+	"Vermont"	"50"	"65 years"	"65"	9771
+	"Vermont"	"50"	"66 years"	"66"	9616
+	"Vermont"	"50"	"67 years"	"67"	9220
+	"Vermont"	"50"	"68 years"	"68"	9083
+	"Vermont"	"50"	"69 years"	"69"	8877
+	"Vermont"	"50"	"70 years"	"70"	8610
+	"Vermont"	"50"	"71 years"	"71"	8269
+	"Vermont"	"50"	"72 years"	"72"	7759
+	"Vermont"	"50"	"73 years"	"73"	7261
+	"Vermont"	"50"	"74 years"	"74"	7075
+	"Vermont"	"50"	"75 years"	"75"	6831
+	"Vermont"	"50"	"76 years"	"76"	7085
+	"Vermont"	"50"	"77 years"	"77"	4861
+	"Vermont"	"50"	"78 years"	"78"	4706
+	"Vermont"	"50"	"79 years"	"79"	4500
+	"Vermont"	"50"	"80 years"	"80"	4479
+	"Vermont"	"50"	"81 years"	"81"	3556
+	"Vermont"	"50"	"82 years"	"82"	3042
+	"Vermont"	"50"	"83 years"	"83"	2659
+	"Vermont"	"50"	"84 years"	"84"	2386
+	"Vermont"	"50"	"85+ years"	"85+"	13477
+"Total"	"Vermont"	"50"			647464
+	"Virginia"	"51"	"< 1 year"	"0"	95290
+	"Virginia"	"51"	"1 year"	"1"	96470
+	"Virginia"	"51"	"2 years"	"2"	94954
+	"Virginia"	"51"	"3 years"	"3"	98571
+	"Virginia"	"51"	"4 years"	"4"	100661
+	"Virginia"	"51"	"5 years"	"5"	102510
+	"Virginia"	"51"	"6 years"	"6"	103275
+	"Virginia"	"51"	"7 years"	"7"	106051
+	"Virginia"	"51"	"8 years"	"8"	105878
+	"Virginia"	"51"	"9 years"	"9"	105302
+	"Virginia"	"51"	"10 years"	"10"	104952
+	"Virginia"	"51"	"11 years"	"11"	105368
+	"Virginia"	"51"	"12 years"	"12"	106247
+	"Virginia"	"51"	"13 years"	"13"	107388
+	"Virginia"	"51"	"14 years"	"14"	109448
+	"Virginia"	"51"	"15 years"	"15"	113792
+	"Virginia"	"51"	"16 years"	"16"	113569
+	"Virginia"	"51"	"17 years"	"17"	111818
+	"Virginia"	"51"	"18 years"	"18"	113556
+	"Virginia"	"51"	"19 years"	"19"	115929
+	"Virginia"	"51"	"20 years"	"20"	115062
+	"Virginia"	"51"	"21 years"	"21"	115837
+	"Virginia"	"51"	"22 years"	"22"	116415
+	"Virginia"	"51"	"23 years"	"23"	113510
+	"Virginia"	"51"	"24 years"	"24"	111300
+	"Virginia"	"51"	"25 years"	"25"	112111
+	"Virginia"	"51"	"26 years"	"26"	111920
+	"Virginia"	"51"	"27 years"	"27"	112954
+	"Virginia"	"51"	"28 years"	"28"	114827
+	"Virginia"	"51"	"29 years"	"29"	117007
+	"Virginia"	"51"	"30 years"	"30"	118273
+	"Virginia"	"51"	"31 years"	"31"	119415
+	"Virginia"	"51"	"32 years"	"32"	121526
+	"Virginia"	"51"	"33 years"	"33"	122666
+	"Virginia"	"51"	"34 years"	"34"	120588
+	"Virginia"	"51"	"35 years"	"35"	119896
+	"Virginia"	"51"	"36 years"	"36"	119796
+	"Virginia"	"51"	"37 years"	"37"	120817
+	"Virginia"	"51"	"38 years"	"38"	120201
+	"Virginia"	"51"	"39 years"	"39"	118203
+	"Virginia"	"51"	"40 years"	"40"	120191
+	"Virginia"	"51"	"41 years"	"41"	119392
+	"Virginia"	"51"	"42 years"	"42"	117850
+	"Virginia"	"51"	"43 years"	"43"	117109
+	"Virginia"	"51"	"44 years"	"44"	112112
+	"Virginia"	"51"	"45 years"	"45"	109180
+	"Virginia"	"51"	"46 years"	"46"	107271
+	"Virginia"	"51"	"47 years"	"47"	102856
+	"Virginia"	"51"	"48 years"	"48"	103867
+	"Virginia"	"51"	"49 years"	"49"	102177
+	"Virginia"	"51"	"50 years"	"50"	103933
+	"Virginia"	"51"	"51 years"	"51"	109443
+	"Virginia"	"51"	"52 years"	"52"	115042
+	"Virginia"	"51"	"53 years"	"53"	112834
+	"Virginia"	"51"	"54 years"	"54"	108651
+	"Virginia"	"51"	"55 years"	"55"	106453
+	"Virginia"	"51"	"56 years"	"56"	106885
+	"Virginia"	"51"	"57 years"	"57"	108146
+	"Virginia"	"51"	"58 years"	"58"	112522
+	"Virginia"	"51"	"59 years"	"59"	114907
+	"Virginia"	"51"	"60 years"	"60"	114274
+	"Virginia"	"51"	"61 years"	"61"	113225
+	"Virginia"	"51"	"62 years"	"62"	111514
+	"Virginia"	"51"	"63 years"	"63"	108123
+	"Virginia"	"51"	"64 years"	"64"	105509
+	"Virginia"	"51"	"65 years"	"65"	103950
+	"Virginia"	"51"	"66 years"	"66"	101302
+	"Virginia"	"51"	"67 years"	"67"	96088
+	"Virginia"	"51"	"68 years"	"68"	93595
+	"Virginia"	"51"	"69 years"	"69"	90057
+	"Virginia"	"51"	"70 years"	"70"	85754
+	"Virginia"	"51"	"71 years"	"71"	81803
+	"Virginia"	"51"	"72 years"	"72"	77684
+	"Virginia"	"51"	"73 years"	"73"	74186
+	"Virginia"	"51"	"74 years"	"74"	72450
+	"Virginia"	"51"	"75 years"	"75"	71372
+	"Virginia"	"51"	"76 years"	"76"	74411
+	"Virginia"	"51"	"77 years"	"77"	51867
+	"Virginia"	"51"	"78 years"	"78"	49153
+	"Virginia"	"51"	"79 years"	"79"	47327
+	"Virginia"	"51"	"80 years"	"80"	47225
+	"Virginia"	"51"	"81 years"	"81"	39342
+	"Virginia"	"51"	"82 years"	"82"	34127
+	"Virginia"	"51"	"83 years"	"83"	30424
+	"Virginia"	"51"	"84 years"	"84"	27145
+	"Virginia"	"51"	"85+ years"	"85+"	149617
+"Total"	"Virginia"	"51"			8715698
+	"Washington"	"53"	"< 1 year"	"0"	82456
+	"Washington"	"53"	"1 year"	"1"	83767
+	"Washington"	"53"	"2 years"	"2"	82734
+	"Washington"	"53"	"3 years"	"3"	85997
+	"Washington"	"53"	"4 years"	"4"	86173
+	"Washington"	"53"	"5 years"	"5"	88489
+	"Washington"	"53"	"6 years"	"6"	91667
+	"Washington"	"53"	"7 years"	"7"	94046
+	"Washington"	"53"	"8 years"	"8"	94280
+	"Washington"	"53"	"9 years"	"9"	93298
+	"Washington"	"53"	"10 years"	"10"	93487
+	"Washington"	"53"	"11 years"	"11"	92850
+	"Washington"	"53"	"12 years"	"12"	93456
+	"Washington"	"53"	"13 years"	"13"	95466
+	"Washington"	"53"	"14 years"	"14"	96729
+	"Washington"	"53"	"15 years"	"15"	99159
+	"Washington"	"53"	"16 years"	"16"	98171
+	"Washington"	"53"	"17 years"	"17"	95845
+	"Washington"	"53"	"18 years"	"18"	89436
+	"Washington"	"53"	"19 years"	"19"	86756
+	"Washington"	"53"	"20 years"	"20"	89309
+	"Washington"	"53"	"21 years"	"21"	90284
+	"Washington"	"53"	"22 years"	"22"	96450
+	"Washington"	"53"	"23 years"	"23"	100920
+	"Washington"	"53"	"24 years"	"24"	102671
+	"Washington"	"53"	"25 years"	"25"	105721
+	"Washington"	"53"	"26 years"	"26"	107620
+	"Washington"	"53"	"27 years"	"27"	111197
+	"Washington"	"53"	"28 years"	"28"	114370
+	"Washington"	"53"	"29 years"	"29"	117991
+	"Washington"	"53"	"30 years"	"30"	121002
+	"Washington"	"53"	"31 years"	"31"	125428
+	"Washington"	"53"	"32 years"	"32"	127924
+	"Washington"	"53"	"33 years"	"33"	128421
+	"Washington"	"53"	"34 years"	"34"	123927
+	"Washington"	"53"	"35 years"	"35"	120310
+	"Washington"	"53"	"36 years"	"36"	118010
+	"Washington"	"53"	"37 years"	"37"	118065
+	"Washington"	"53"	"38 years"	"38"	116636
+	"Washington"	"53"	"39 years"	"39"	113805
+	"Washington"	"53"	"40 years"	"40"	114506
+	"Washington"	"53"	"41 years"	"41"	113027
+	"Washington"	"53"	"42 years"	"42"	109855
+	"Washington"	"53"	"43 years"	"43"	107035
+	"Washington"	"53"	"44 years"	"44"	101406
+	"Washington"	"53"	"45 years"	"45"	97544
+	"Washington"	"53"	"46 years"	"46"	95506
+	"Washington"	"53"	"47 years"	"47"	91613
+	"Washington"	"53"	"48 years"	"48"	91262
+	"Washington"	"53"	"49 years"	"49"	88362
+	"Washington"	"53"	"50 years"	"50"	88219
+	"Washington"	"53"	"51 years"	"51"	91577
+	"Washington"	"53"	"52 years"	"52"	98268
+	"Washington"	"53"	"53 years"	"53"	97421
+	"Washington"	"53"	"54 years"	"54"	93635
+	"Washington"	"53"	"55 years"	"55"	89442
+	"Washington"	"53"	"56 years"	"56"	87661
+	"Washington"	"53"	"57 years"	"57"	87828
+	"Washington"	"53"	"58 years"	"58"	90833
+	"Washington"	"53"	"59 years"	"59"	93675
+	"Washington"	"53"	"60 years"	"60"	95299
+	"Washington"	"53"	"61 years"	"61"	95679
+	"Washington"	"53"	"62 years"	"62"	95626
+	"Washington"	"53"	"63 years"	"63"	93643
+	"Washington"	"53"	"64 years"	"64"	91876
+	"Washington"	"53"	"65 years"	"65"	91567
+	"Washington"	"53"	"66 years"	"66"	90503
+	"Washington"	"53"	"67 years"	"67"	87319
+	"Washington"	"53"	"68 years"	"68"	85602
+	"Washington"	"53"	"69 years"	"69"	83303
+	"Washington"	"53"	"70 years"	"70"	79996
+	"Washington"	"53"	"71 years"	"71"	76518
+	"Washington"	"53"	"72 years"	"72"	71819
+	"Washington"	"53"	"73 years"	"73"	68090
+	"Washington"	"53"	"74 years"	"74"	65724
+	"Washington"	"53"	"75 years"	"75"	63265
+	"Washington"	"53"	"76 years"	"76"	66063
+	"Washington"	"53"	"77 years"	"77"	45556
+	"Washington"	"53"	"78 years"	"78"	43478
+	"Washington"	"53"	"79 years"	"79"	41611
+	"Washington"	"53"	"80 years"	"80"	40347
+	"Washington"	"53"	"81 years"	"81"	33245
+	"Washington"	"53"	"82 years"	"82"	28747
+	"Washington"	"53"	"83 years"	"83"	25212
+	"Washington"	"53"	"84 years"	"84"	22652
+	"Washington"	"53"	"85+ years"	"85+"	127142
+"Total"	"Washington"	"53"			7812880
+	"West Virginia"	"54"	"< 1 year"	"0"	17135
+	"West Virginia"	"54"	"1 year"	"1"	17178
+	"West Virginia"	"54"	"2 years"	"2"	17288
+	"West Virginia"	"54"	"3 years"	"3"	17875
+	"West Virginia"	"54"	"4 years"	"4"	17923
+	"West Virginia"	"54"	"5 years"	"5"	18330
+	"West Virginia"	"54"	"6 years"	"6"	18642
+	"West Virginia"	"54"	"7 years"	"7"	19220
+	"West Virginia"	"54"	"8 years"	"8"	19774
+	"West Virginia"	"54"	"9 years"	"9"	20119
+	"West Virginia"	"54"	"10 years"	"10"	20309
+	"West Virginia"	"54"	"11 years"	"11"	20110
+	"West Virginia"	"54"	"12 years"	"12"	20285
+	"West Virginia"	"54"	"13 years"	"13"	20668
+	"West Virginia"	"54"	"14 years"	"14"	21245
+	"West Virginia"	"54"	"15 years"	"15"	22300
+	"West Virginia"	"54"	"16 years"	"16"	22089
+	"West Virginia"	"54"	"17 years"	"17"	21722
+	"West Virginia"	"54"	"18 years"	"18"	21663
+	"West Virginia"	"54"	"19 years"	"19"	22022
+	"West Virginia"	"54"	"20 years"	"20"	22163
+	"West Virginia"	"54"	"21 years"	"21"	22596
+	"West Virginia"	"54"	"22 years"	"22"	22941
+	"West Virginia"	"54"	"23 years"	"23"	22549
+	"West Virginia"	"54"	"24 years"	"24"	21371
+	"West Virginia"	"54"	"25 years"	"25"	20912
+	"West Virginia"	"54"	"26 years"	"26"	20582
+	"West Virginia"	"54"	"27 years"	"27"	20753
+	"West Virginia"	"54"	"28 years"	"28"	20891
+	"West Virginia"	"54"	"29 years"	"29"	21122
+	"West Virginia"	"54"	"30 years"	"30"	21373
+	"West Virginia"	"54"	"31 years"	"31"	22105
+	"West Virginia"	"54"	"32 years"	"32"	22656
+	"West Virginia"	"54"	"33 years"	"33"	22272
+	"West Virginia"	"54"	"34 years"	"34"	21408
+	"West Virginia"	"54"	"35 years"	"35"	20402
+	"West Virginia"	"54"	"36 years"	"36"	20235
+	"West Virginia"	"54"	"37 years"	"37"	20158
+	"West Virginia"	"54"	"38 years"	"38"	20295
+	"West Virginia"	"54"	"39 years"	"39"	20001
+	"West Virginia"	"54"	"40 years"	"40"	21184
+	"West Virginia"	"54"	"41 years"	"41"	21584
+	"West Virginia"	"54"	"42 years"	"42"	21911
+	"West Virginia"	"54"	"43 years"	"43"	22358
+	"West Virginia"	"54"	"44 years"	"44"	22078
+	"West Virginia"	"54"	"45 years"	"45"	21895
+	"West Virginia"	"54"	"46 years"	"46"	21848
+	"West Virginia"	"54"	"47 years"	"47"	20864
+	"West Virginia"	"54"	"48 years"	"48"	21394
+	"West Virginia"	"54"	"49 years"	"49"	21100
+	"West Virginia"	"54"	"50 years"	"50"	21752
+	"West Virginia"	"54"	"51 years"	"51"	23016
+	"West Virginia"	"54"	"52 years"	"52"	24471
+	"West Virginia"	"54"	"53 years"	"53"	23423
+	"West Virginia"	"54"	"54 years"	"54"	22496
+	"West Virginia"	"54"	"55 years"	"55"	22012
+	"West Virginia"	"54"	"56 years"	"56"	22387
+	"West Virginia"	"54"	"57 years"	"57"	22610
+	"West Virginia"	"54"	"58 years"	"58"	23509
+	"West Virginia"	"54"	"59 years"	"59"	23997
+	"West Virginia"	"54"	"60 years"	"60"	23858
+	"West Virginia"	"54"	"61 years"	"61"	23902
+	"West Virginia"	"54"	"62 years"	"62"	24383
+	"West Virginia"	"54"	"63 years"	"63"	24123
+	"West Virginia"	"54"	"64 years"	"64"	24555
+	"West Virginia"	"54"	"65 years"	"65"	24928
+	"West Virginia"	"54"	"66 years"	"66"	24689
+	"West Virginia"	"54"	"67 years"	"67"	23653
+	"West Virginia"	"54"	"68 years"	"68"	23451
+	"West Virginia"	"54"	"69 years"	"69"	22847
+	"West Virginia"	"54"	"70 years"	"70"	22265
+	"West Virginia"	"54"	"71 years"	"71"	21900
+	"West Virginia"	"54"	"72 years"	"72"	20825
+	"West Virginia"	"54"	"73 years"	"73"	19904
+	"West Virginia"	"54"	"74 years"	"74"	19637
+	"West Virginia"	"54"	"75 years"	"75"	18770
+	"West Virginia"	"54"	"76 years"	"76"	19555
+	"West Virginia"	"54"	"77 years"	"77"	12811
+	"West Virginia"	"54"	"78 years"	"78"	12102
+	"West Virginia"	"54"	"79 years"	"79"	11676
+	"West Virginia"	"54"	"80 years"	"80"	11648
+	"West Virginia"	"54"	"81 years"	"81"	9718
+	"West Virginia"	"54"	"82 years"	"82"	8732
+	"West Virginia"	"54"	"83 years"	"83"	7626
+	"West Virginia"	"54"	"84 years"	"84"	6917
+	"West Virginia"	"54"	"85+ years"	"85+"	37025
+"Total"	"West Virginia"	"54"			1770071
+	"Wisconsin"	"55"	"< 1 year"	"0"	59547
+	"Wisconsin"	"55"	"1 year"	"1"	61005
+	"Wisconsin"	"55"	"2 years"	"2"	60616
+	"Wisconsin"	"55"	"3 years"	"3"	64385
+	"Wisconsin"	"55"	"4 years"	"4"	64821
+	"Wisconsin"	"55"	"5 years"	"5"	65992
+	"Wisconsin"	"55"	"6 years"	"6"	67691
+	"Wisconsin"	"55"	"7 years"	"7"	69410
+	"Wisconsin"	"55"	"8 years"	"8"	69754
+	"Wisconsin"	"55"	"9 years"	"9"	69686
+	"Wisconsin"	"55"	"10 years"	"10"	69678
+	"Wisconsin"	"55"	"11 years"	"11"	70182
+	"Wisconsin"	"55"	"12 years"	"12"	70958
+	"Wisconsin"	"55"	"13 years"	"13"	74100
+	"Wisconsin"	"55"	"14 years"	"14"	76188
+	"Wisconsin"	"55"	"15 years"	"15"	78736
+	"Wisconsin"	"55"	"16 years"	"16"	78792
+	"Wisconsin"	"55"	"17 years"	"17"	77588
+	"Wisconsin"	"55"	"18 years"	"18"	75770
+	"Wisconsin"	"55"	"19 years"	"19"	79534
+	"Wisconsin"	"55"	"20 years"	"20"	79801
+	"Wisconsin"	"55"	"21 years"	"21"	79509
+	"Wisconsin"	"55"	"22 years"	"22"	81724
+	"Wisconsin"	"55"	"23 years"	"23"	80334
+	"Wisconsin"	"55"	"24 years"	"24"	75727
+	"Wisconsin"	"55"	"25 years"	"25"	73814
+	"Wisconsin"	"55"	"26 years"	"26"	72716
+	"Wisconsin"	"55"	"27 years"	"27"	72230
+	"Wisconsin"	"55"	"28 years"	"28"	72976
+	"Wisconsin"	"55"	"29 years"	"29"	74880
+	"Wisconsin"	"55"	"30 years"	"30"	75728
+	"Wisconsin"	"55"	"31 years"	"31"	76247
+	"Wisconsin"	"55"	"32 years"	"32"	74647
+	"Wisconsin"	"55"	"33 years"	"33"	74068
+	"Wisconsin"	"55"	"34 years"	"34"	72537
+	"Wisconsin"	"55"	"35 years"	"35"	72085
+	"Wisconsin"	"55"	"36 years"	"36"	73001
+	"Wisconsin"	"55"	"37 years"	"37"	74862
+	"Wisconsin"	"55"	"38 years"	"38"	76281
+	"Wisconsin"	"55"	"39 years"	"39"	75010
+	"Wisconsin"	"55"	"40 years"	"40"	76459
+	"Wisconsin"	"55"	"41 years"	"41"	76826
+	"Wisconsin"	"55"	"42 years"	"42"	76264
+	"Wisconsin"	"55"	"43 years"	"43"	75757
+	"Wisconsin"	"55"	"44 years"	"44"	72772
+	"Wisconsin"	"55"	"45 years"	"45"	70671
+	"Wisconsin"	"55"	"46 years"	"46"	68980
+	"Wisconsin"	"55"	"47 years"	"47"	65756
+	"Wisconsin"	"55"	"48 years"	"48"	66195
+	"Wisconsin"	"55"	"49 years"	"49"	64156
+	"Wisconsin"	"55"	"50 years"	"50"	64459
+	"Wisconsin"	"55"	"51 years"	"51"	68575
+	"Wisconsin"	"55"	"52 years"	"52"	74116
+	"Wisconsin"	"55"	"53 years"	"53"	73705
+	"Wisconsin"	"55"	"54 years"	"54"	72149
+	"Wisconsin"	"55"	"55 years"	"55"	71691
+	"Wisconsin"	"55"	"56 years"	"56"	74097
+	"Wisconsin"	"55"	"57 years"	"57"	76029
+	"Wisconsin"	"55"	"58 years"	"58"	79530
+	"Wisconsin"	"55"	"59 years"	"59"	82257
+	"Wisconsin"	"55"	"60 years"	"60"	83107
+	"Wisconsin"	"55"	"61 years"	"61"	84674
+	"Wisconsin"	"55"	"62 years"	"62"	85505
+	"Wisconsin"	"55"	"63 years"	"63"	83003
+	"Wisconsin"	"55"	"64 years"	"64"	81810
+	"Wisconsin"	"55"	"65 years"	"65"	80746
+	"Wisconsin"	"55"	"66 years"	"66"	78656
+	"Wisconsin"	"55"	"67 years"	"67"	74407
+	"Wisconsin"	"55"	"68 years"	"68"	72785
+	"Wisconsin"	"55"	"69 years"	"69"	70147
+	"Wisconsin"	"55"	"70 years"	"70"	67207
+	"Wisconsin"	"55"	"71 years"	"71"	64835
+	"Wisconsin"	"55"	"72 years"	"72"	60734
+	"Wisconsin"	"55"	"73 years"	"73"	56631
+	"Wisconsin"	"55"	"74 years"	"74"	54079
+	"Wisconsin"	"55"	"75 years"	"75"	51331
+	"Wisconsin"	"55"	"76 years"	"76"	53169
+	"Wisconsin"	"55"	"77 years"	"77"	35839
+	"Wisconsin"	"55"	"78 years"	"78"	34358
+	"Wisconsin"	"55"	"79 years"	"79"	33234
+	"Wisconsin"	"55"	"80 years"	"80"	33440
+	"Wisconsin"	"55"	"81 years"	"81"	28135
+	"Wisconsin"	"55"	"82 years"	"82"	24528
+	"Wisconsin"	"55"	"83 years"	"83"	21594
+	"Wisconsin"	"55"	"84 years"	"84"	19914
+	"Wisconsin"	"55"	"85+ years"	"85+"	114033
+"Total"	"Wisconsin"	"55"			5910955
+	"Wyoming"	"56"	"< 1 year"	"0"	5847
+	"Wyoming"	"56"	"1 year"	"1"	6071
+	"Wyoming"	"56"	"2 years"	"2"	6126
+	"Wyoming"	"56"	"3 years"	"3"	6332
+	"Wyoming"	"56"	"4 years"	"4"	6409
+	"Wyoming"	"56"	"5 years"	"5"	6641
+	"Wyoming"	"56"	"6 years"	"6"	6951
+	"Wyoming"	"56"	"7 years"	"7"	7346
+	"Wyoming"	"56"	"8 years"	"8"	7320
+	"Wyoming"	"56"	"9 years"	"9"	7377
+	"Wyoming"	"56"	"10 years"	"10"	7402
+	"Wyoming"	"56"	"11 years"	"11"	7304
+	"Wyoming"	"56"	"12 years"	"12"	7513
+	"Wyoming"	"56"	"13 years"	"13"	7827
+	"Wyoming"	"56"	"14 years"	"14"	8169
+	"Wyoming"	"56"	"15 years"	"15"	8394
+	"Wyoming"	"56"	"16 years"	"16"	8364
+	"Wyoming"	"56"	"17 years"	"17"	8156
+	"Wyoming"	"56"	"18 years"	"18"	7653
+	"Wyoming"	"56"	"19 years"	"19"	7782
+	"Wyoming"	"56"	"20 years"	"20"	7646
+	"Wyoming"	"56"	"21 years"	"21"	7700
+	"Wyoming"	"56"	"22 years"	"22"	7959
+	"Wyoming"	"56"	"23 years"	"23"	7563
+	"Wyoming"	"56"	"24 years"	"24"	7136
+	"Wyoming"	"56"	"25 years"	"25"	6991
+	"Wyoming"	"56"	"26 years"	"26"	7044
+	"Wyoming"	"56"	"27 years"	"27"	6864
+	"Wyoming"	"56"	"28 years"	"28"	6869
+	"Wyoming"	"56"	"29 years"	"29"	7191
+	"Wyoming"	"56"	"30 years"	"30"	7237
+	"Wyoming"	"56"	"31 years"	"31"	7549
+	"Wyoming"	"56"	"32 years"	"32"	7691
+	"Wyoming"	"56"	"33 years"	"33"	7810
+	"Wyoming"	"56"	"34 years"	"34"	7567
+	"Wyoming"	"56"	"35 years"	"35"	7479
+	"Wyoming"	"56"	"36 years"	"36"	7652
+	"Wyoming"	"56"	"37 years"	"37"	7845
+	"Wyoming"	"56"	"38 years"	"38"	8048
+	"Wyoming"	"56"	"39 years"	"39"	7994
+	"Wyoming"	"56"	"40 years"	"40"	8075
+	"Wyoming"	"56"	"41 years"	"41"	8084
+	"Wyoming"	"56"	"42 years"	"42"	7866
+	"Wyoming"	"56"	"43 years"	"43"	7876
+	"Wyoming"	"56"	"44 years"	"44"	7444
+	"Wyoming"	"56"	"45 years"	"45"	7137
+	"Wyoming"	"56"	"46 years"	"46"	6958
+	"Wyoming"	"56"	"47 years"	"47"	6564
+	"Wyoming"	"56"	"48 years"	"48"	6588
+	"Wyoming"	"56"	"49 years"	"49"	6346
+	"Wyoming"	"56"	"50 years"	"50"	6267
+	"Wyoming"	"56"	"51 years"	"51"	6463
+	"Wyoming"	"56"	"52 years"	"52"	6858
+	"Wyoming"	"56"	"53 years"	"53"	6837
+	"Wyoming"	"56"	"54 years"	"54"	6422
+	"Wyoming"	"56"	"55 years"	"55"	6118
+	"Wyoming"	"56"	"56 years"	"56"	6224
+	"Wyoming"	"56"	"57 years"	"57"	6177
+	"Wyoming"	"56"	"58 years"	"58"	6737
+	"Wyoming"	"56"	"59 years"	"59"	7200
+	"Wyoming"	"56"	"60 years"	"60"	7406
+	"Wyoming"	"56"	"61 years"	"61"	7639
+	"Wyoming"	"56"	"62 years"	"62"	8046
+	"Wyoming"	"56"	"63 years"	"63"	8065
+	"Wyoming"	"56"	"64 years"	"64"	7976
+	"Wyoming"	"56"	"65 years"	"65"	7952
+	"Wyoming"	"56"	"66 years"	"66"	8068
+	"Wyoming"	"56"	"67 years"	"67"	7762
+	"Wyoming"	"56"	"68 years"	"68"	7550
+	"Wyoming"	"56"	"69 years"	"69"	7246
+	"Wyoming"	"56"	"70 years"	"70"	6947
+	"Wyoming"	"56"	"71 years"	"71"	6511
+	"Wyoming"	"56"	"72 years"	"72"	5991
+	"Wyoming"	"56"	"73 years"	"73"	5642
+	"Wyoming"	"56"	"74 years"	"74"	5364
+	"Wyoming"	"56"	"75 years"	"75"	5066
+	"Wyoming"	"56"	"76 years"	"76"	5359
+	"Wyoming"	"56"	"77 years"	"77"	3493
+	"Wyoming"	"56"	"78 years"	"78"	3391
+	"Wyoming"	"56"	"79 years"	"79"	3272
+	"Wyoming"	"56"	"80 years"	"80"	3162
+	"Wyoming"	"56"	"81 years"	"81"	2599
+	"Wyoming"	"56"	"82 years"	"82"	2263
+	"Wyoming"	"56"	"83 years"	"83"	2018
+	"Wyoming"	"56"	"84 years"	"84"	1838
+	"Wyoming"	"56"	"85+ years"	"85+"	10371
+"Total"	"Wyoming"	"56"			584057
+"Total"					334914895
+"---"
+"Dataset: Single-Race Population Estimates 2020-2023 by State and Single-Year Age"
+"Query Parameters:"
+"Yearly July 1st Estimates: 2023"
+"Group By: States; Single-Year Ages"
+"Show Totals: True"
+"Show Zero Values: False"
+"---"
+"Help: See http://wonder.cdc.gov/wonder/help/single-race.html for more information."
+"---"
+"Query Date: Apr 24, 2025 8:18:41 PM"
+"---"
+"Suggested Citation: Single-race Population Estimates, United States, 2020-2023. July 1st resident population by state, age, sex,"
+"single-race, and Hispanic origin, on CDC WONDER Online Database. The 2020-2023 postcensal series of estimates of the July 1"
+"resident population are based on the Blended Base produced by the US Census Bureau in lieu of the April 1, 2020 decennial"
+"population count, released by the Census Bureau on June 22, 2023. Accessed at"
+"http://wonder.cdc.gov/single-race-single-year-v2023.html on Apr 24, 2025 8:18:41 PM"
+"---"
+Messages:
+"1. Rows with zero Population are hidden. Use Quick Options above to show zero rows."
+"---"
+Footnotes:
+"1. Estimates for 2020-2023 are single-race Vintage 2023 postcensal estimates of the July 1 resident population, based on the"
+"modified Blended Base produced by the US Census Bureau in lieu of the April 1, 2020 decennial population count, and released by"
+"the Census Bureau on March 14, 2024."
+"---"
+Caveats:


### PR DESCRIPTION
Calculated population-weighted national level of Outcome_value1, and appended the average to combined_file_XX:
- Code incorporated into `CleanAndHarmonize.R`
- State-level population level data added in `Data/other_data` folder: `Single-Race Population Estimates 2020-2023 by State and Single-Year Age.csv`